### PR TITLE
Add Client.me() method to get current permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,14 @@ jobs:
         run: pip3 install .[test]
 
       - name: Run Reduct Storage
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{matrix.token}} -d ghcr.io/reductstore/reductstore:latest
+        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{matrix.token}} --env RS_LOG_LEVEL=DEBUG -d ghcr.io/reductstore/reductstore:latest
 
       - name: Run Tests
         run: PYTHONPATH=. RS_API_TOKEN=${{matrix.token}} pytest tests
+
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2
 
   pylint:
     needs: build

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,0 @@
-[MASTER]
-
-max-line-length = 88
-extension-pkg-whitelist=pydantic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- Client.me() method to get current permissions, [PR-62](https://github.com/reductstore/reduct-py/pull/62)
+
 ### Changed:
 
 - Update documentation after rebranding, [PR-59](https://github.com/reductstore/reduct-py/pull/59)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,4 @@ asyncio_mode = "strict"
 [tool.pylint]
 max-line-length = 88
 extension-pkg-whitelist = "pydantic"
+good-names = "me"

--- a/reduct/client.py
+++ b/reduct/client.py
@@ -94,7 +94,7 @@ class Client:
     """HTTP Client for Reduct Storage HTTP API"""
 
     def __init__(
-            self, url: str, api_token: Optional[str] = None, timeout: Optional[float] = None
+        self, url: str, api_token: Optional[str] = None, timeout: Optional[float] = None
     ):
         """
         Constructor
@@ -149,10 +149,10 @@ class Client:
         return Bucket(name, self._http)
 
     async def create_bucket(
-            self,
-            name: str,
-            settings: Optional[BucketSettings] = None,
-            exist_ok: bool = False,
+        self,
+        name: str,
+        settings: Optional[BucketSettings] = None,
+        exist_ok: bool = False,
     ) -> Bucket:
         """
         Create a new bucket

--- a/reduct/client.py
+++ b/reduct/client.py
@@ -94,7 +94,7 @@ class Client:
     """HTTP Client for Reduct Storage HTTP API"""
 
     def __init__(
-        self, url: str, api_token: Optional[str] = None, timeout: Optional[float] = None
+            self, url: str, api_token: Optional[str] = None, timeout: Optional[float] = None
     ):
         """
         Constructor
@@ -149,10 +149,10 @@ class Client:
         return Bucket(name, self._http)
 
     async def create_bucket(
-        self,
-        name: str,
-        settings: Optional[BucketSettings] = None,
-        exist_ok: bool = False,
+            self,
+            name: str,
+            settings: Optional[BucketSettings] = None,
+            exist_ok: bool = False,
     ) -> Bucket:
         """
         Create a new bucket
@@ -228,3 +228,13 @@ class Client:
             ReductError: if there is an HTTP error
         """
         await self._http.request_all("DELETE", f"/tokens/{name}")
+
+    async def me(self) -> FullTokenInfo:
+        """
+        Get information about the current token
+        Returns:
+            FullTokenInfo
+        Raises:
+            ReductError: if there is an HTTP error
+        """
+        return FullTokenInfo.parse_raw(await self._http.request_all("GET", "/me"))

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -12,7 +12,8 @@ from reduct import (
     BucketInfo,
     QuotaType,
     BucketSettings,
-    Permissions, FullTokenInfo,
+    Permissions,
+    FullTokenInfo,
 )
 from .conftest import requires_env
 
@@ -166,7 +167,7 @@ async def test__create_token(client):
 async def test__create_token_with_error(client, with_token):
     """Should raise an error, if token exists"""
     with pytest.raises(
-            ReductError, match="Status 409: Token 'test-token' already exists"
+        ReductError, match="Status 409: Token 'test-token' already exists"
     ):
         await client.create_token(
             with_token, Permissions(full_access=True, read=[], write=[])
@@ -213,7 +214,7 @@ async def test__remove_token(client, with_token):
     """Should delete a token"""
     await client.remove_token(with_token)
     with pytest.raises(
-            ReductError, match="Status 404: Token 'test-token' doesn't exist"
+        ReductError, match="Status 404: Token 'test-token' doesn't exist"
     ):
         await client.get_token(with_token)
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -223,9 +223,9 @@ async def test__remove_token(client, with_token):
 @pytest.mark.asyncio
 async def test__me(client):
     """Should get user info"""
-    me: FullTokenInfo = await client.me()
-    assert me.name == "init-token"
-    assert me.permissions.dict() == {
+    current_token: FullTokenInfo = await client.me()
+    assert current_token.name == "init-token"
+    assert current_token.permissions.dict() == {
         "full_access": True,
         "read": [],
         "write": [],


### PR DESCRIPTION
Closes #57

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #57 

### What is the new behavior?

I added the `Client.me()` method which returns the name and permission for the current API token by using `GET /api/v1/me` endpoint.

### Does this PR introduce a breaking change?

No

### Other information:
