### PR TITLE
Read and write with content type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install --no-cache --upgrade pip setuptools wheel
 
@@ -25,7 +25,7 @@ jobs:
     needs: format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install --no-cache --upgrade pip pipx
 
@@ -41,11 +41,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install --no-cache --upgrade pip pipx
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@master
         with:
           name: package
@@ -71,7 +71,7 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         token: ["", "ACCESS_TOKEN"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@master
         with:
           name: package
@@ -110,7 +110,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@master
         with:
           name: package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './logs'
       - name: Tar logs
         if: failure()
         run: tar cvzf ./logs.tgz ./logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Quick Start example and guide, [PR-65](https://github.com/reductstore/reduct-py/pull/65)
 - Support labels for read, write and querying, [PR-66](https://github.com/reductstore/reduct-py/pull/66)
+- 'Content-Type' header for read and write operations, [PR-67](https://github.com/reductstore/reduct-py/pull/67)
 
 ## [1.2.0] - 2022-12-22
 

--- a/reduct/http.py
+++ b/reduct/http.py
@@ -34,6 +34,11 @@ class HttpClient:
         if "content_length" in kwargs:
             extra_headers["Content-Length"] = str(kwargs["content_length"])
             del kwargs["content_length"]
+
+        if "content_type" in kwargs:
+            extra_headers["Content-Type"] = str(kwargs["content_type"])
+            del kwargs["content_type"]
+
         if "labels" in kwargs:
             if kwargs["labels"]:
                 for name, value in kwargs["labels"].items():
@@ -68,7 +73,7 @@ class HttpClient:
         async with self.request(method, path, **kwargs) as response:
             return await response.read()
 
-    async def request_by(
+    async def request_chunked(
         self, method: str, path: str = "", chunk_size=1024, **kwargs
     ) -> AsyncIterator[bytes]:
         """Http request"""

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -90,6 +90,9 @@ async def test__read_by_timestamp(bucket_1):
     async with bucket_1.read("entry-2", timestamp=3_000_000) as record:
         data = await record.read_all()
         assert data == b"some-data-3"
+        assert record.timestamp == 3_000_000
+        assert record.size == 11
+        assert record.content_type == "application/octet-stream"
 
 
 @pytest.mark.asyncio
@@ -137,7 +140,7 @@ async def test__write_in_chunks(bucket_2):
 
 @pytest.mark.asyncio
 async def test__write_with_labels(bucket_1):
-    """Schould write data with labels"""
+    """Should write data with labels"""
     await bucket_1.write(
         "entry-1", b"something", labels={"label1": 123, "label2": 0.1, "label3": "hey"}
     )
@@ -145,6 +148,17 @@ async def test__write_with_labels(bucket_1):
         data = await record.read_all()
         assert data == b"something"
         assert record.labels == {"label1": "123", "label2": "0.1", "label3": "hey"}
+
+
+@pytest.mark.asyncio
+async def test__write_with_content_type(bucket_1):
+    """Should write data with content_type"""
+    await bucket_1.write("entry-1", b"something", content_type="text/plain")
+
+    async with bucket_1.read("entry-1") as record:
+        data = await record.read_all()
+        assert data == b"something"
+        assert record.content_type == "text/plain"
 
 
 @pytest.mark.asyncio
@@ -158,10 +172,12 @@ async def test_query_records(bucket_1):
 
     assert records[0].timestamp == 3000000
     assert records[0].size == 11
+    assert records[0].content_type == "application/octet-stream"
     assert not records[0].last
 
     assert records[1].timestamp == 4000000
     assert records[1].size == 11
+    assert records[1].content_type == "application/octet-stream"
     assert records[1].last
 
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feautre

### What is the current behavior?

Since version 1.3, ReductStore supports the Conten-Type header, but the SDK doesn't"t provide an API for this.
 
### What is the new behavior?

No, you can write and read records with the content type:

```python
    await bucket_1.write("entry-1", b"something", content_type="text/plain")

    async with bucket_1.read("entry-1") as record:
        data = await record.read_all()
        assert data == b"something"
        assert record.content_type == "text/plain"
```

### Does this PR introduce a breaking change?

No

### Other information:
