### PR TITLE
Use status 204 (no content) to stop querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- No content status in `Bucket.query`, [PR-69](https://github.com/reductstore/reduct-py/pull/69)
+
 ### [1.3.0] - 2023-01-27
 
 ### Added:

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -318,7 +318,7 @@ class Bucket:
         last = False
         while not last:
             async with self._http.request("GET", f"{url}?q={query_id}") as resp:
-                if resp.status == 202:
+                if resp.status == 204:
                     return
                 last = int(resp.headers["x-reduct-last"]) != 0
                 yield _parse_record(resp, last)

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -265,3 +265,13 @@ async def test_read_record(bucket_1):
             data.append(chunk)
 
     assert data == [b"some", b"-dat", b"a-3", b"some", b"-dat", b"a-4"]
+
+
+@pytest.mark.asyncio
+async def test_no_content_query(bucket_1):
+    """Should return empty list if no content"""
+    records = [
+        record
+        async for record in bucket_1.query("entry-2", include={"label1": "value1"})
+    ]
+    assert len(records) == 0


### PR DESCRIPTION
Closes #68 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #68 

### What is the new behavior?

Fix check of HTTP status in the `Bucket.query` method.

### Does this PR introduce a breaking change?

No

### Other information:
