### PR TITLE
Subscripting to new records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,10 @@ jobs:
         run: python3 -m pip install dist/*.whl
 
       - name: Run ReductStore
-        run: docker run -p 8383:8383 -d ghcr.io/reductstore/reductstore:main
+        run: docker run -p 8383:8383 -d reduct/store:main
 
       - name: Run examples
-        run: python3 examples/quick_start.py
+        run: find examples/ -name *.py | xargs python3
 
   test:
     needs: build
@@ -88,7 +88,7 @@ jobs:
         run: pip3 install .[test]
 
       - name: Run ReductStore
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{matrix.token}} --env RS_LOG_LEVEL=DEBUG -d ghcr.io/reductstore/reductstore:main
+        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{matrix.token}} --env RS_LOG_LEVEL=DEBUG -d reduct/store:main
 
       - name: Run Tests
         run: PYTHONPATH=. RS_API_TOKEN=${{matrix.token}} pytest tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- Subscripting to new records, [PR-70](https://github.com/reductstore/reduct-py/pull/70)
+
 ## [1.3.1] - 2023-01-30
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ This package provides an asynchronous HTTP client for interacting with the [Redu
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.3](https://docs.reduct.store/http-api)
-* Asynchronous and based on aiohttp and pydantic
+* Supports the [ReductStore HTTP API v1.4](https://docs.reduct.store/http-api)
+* Bucket management
+* API Token management
+* Write, read and query data
+* Labels
+* Subscription on new data
 
 ## Install
 
@@ -29,8 +33,8 @@ import asyncio
 from reduct import Client, Bucket
 
 async def main():
-    # Create a client for interacting with the ReductStore service
-    client = Client('https://play.reduct.store', api_token="reduct")
+    # Create a client for interacting with a ReductStore service
+    client = Client("http://localhost:80383")
 
     # Create a bucket and store a reference to it in the `bucket` variable
     bucket: Bucket = await client.create_bucket("my-bucket", exist_ok=True)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ loop = asyncio.get_event_loop()
 loop.run_until_complete(main())
 ```
 
-For more examples, see the [Quick Start](https://py.reduct.store/en/latest/docs/quick-start/).
+For more examples, see the [Quick Start](https://py.reduct.storgit ce/en/latest/docs/quick-start/).
 
 ## References
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -18,7 +18,7 @@ If you don't already have a ReductStore instance running, you can easily spin on
 run the following command:
 
 ```
-docker run -p 8383:8383 reductstore/reductstore
+docker run -p 8383:8383 reduct/store:latest
 ```
 
 This will start a ReductStore instance listening on port 8383 of your local machine.

--- a/docs/subscripting.md
+++ b/docs/subscripting.md
@@ -1,0 +1,55 @@
+# Subscripting to Data
+
+This guide shows you how to use [ReductStore Python SDK](https://py.reduct.store/en/latest/) to subscribe to new
+records in a bucket.
+
+## Prerequisites
+
+If you don't have a ReductStore instance running, you can easily spin one up as a Docker container. To do this, run the
+following command:
+
+```bash
+docker run -p 8383:8383 reduct/store:latest
+```
+
+Also, if you haven't already installed the SDK, you can use the `pip` package manager to install the `reduct-py`
+package:
+
+```bash
+pip install reduct-py
+```
+
+## Example
+
+For demonstration purposes, we will create a script with two coroutines:
+
+1. `writer` will write data to an entry in a bucket with the current timestamp and the label `good`.
+2. `subscriber` will subscribe to the entry and records which have the label `good` equal to `True`.
+
+When the `subscriber` will receive 10 records, it stops the subscription and the `writer`.
+
+This is the whole script:
+
+```python title="subscripting.py"
+--8<-- "../examples/subscripting.py:"
+```
+
+The most important part of the script is the `subscriber` coroutine:
+
+```python title="subscripting.py"
+--8<-- "../examples/subscripting.py:subscriber"
+```
+
+The `subcribe` method queries records from the `entry-1` entry from the current time and subscribes to new records that have
+the label `good` equal `true`. Since [ReductStore](https://www.reduct.store) provides an HTTP API, the `subscribe` method polls the entry for
+each `poll_interval` seconds.
+
+## When to use subscripting
+
+Subscripting is useful when you want your application to be notified when new records are added to an entry. Some possible
+use cases are:
+
+* You can use ReductStore as a simple message broker with persistent storage.
+* Replication of data from one ReductStore instance to another one. For example, your can subscribe to records with certain labels
+  and write them to another ReductStore instance for long-term storage.
+* Ingesting data from a ReductStore instance to a data warehouse.

--- a/examples/subscripting.py
+++ b/examples/subscripting.py
@@ -29,7 +29,7 @@ async def subscriber():
     async for record in bucket.subscribe(
         "entry-1",
         start=int(time_ns() / 10000),
-        poll_interval=1,
+        poll_interval=0.2,
         include=dict(good=True),
     ):
         print(f"Good record received: ts={record.timestamp}, labels={record.labels}")

--- a/examples/subscripting.py
+++ b/examples/subscripting.py
@@ -20,13 +20,17 @@ async def writer():
         await asyncio.sleep(1)
 
 
+# --8<-- [start:subscriber]
 async def subscriber():
     """Subscribe on good records and exit after ten received"""
     global running
     bucket: Bucket = await client.create_bucket("bucket", exist_ok=True)
     counter = 0
     async for record in bucket.subscribe(
-        "entry-1", start=int(time_ns() / 10000), include=dict(good=True)
+        "entry-1",
+        start=int(time_ns() / 10000),
+        poll_interval=1,
+        include=dict(good=True),
     ):
         print(f"Good record received: ts={record.timestamp}, labels={record.labels}")
         counter += 1
@@ -34,6 +38,8 @@ async def subscriber():
             running = False
             break
 
+
+# --8<-- [end:subscriber]
 
 if __name__ == "__main__":
     loop = asyncio.new_event_loop()

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -1,0 +1,44 @@
+import asyncio
+from time import time_ns
+
+from reduct import Client, Bucket
+
+client = Client("http://127.0.0.1:8383")
+running = True
+
+
+async def writer():
+    """Write a blob with toggling good flag"""
+    bucket: Bucket = await client.create_bucket("bucket", exist_ok=True)
+    good = True
+    while running:
+        data = b"Some blob of data"
+        ts = int(time_ns() / 10000)
+        await bucket.write("entry-1", data, ts, labels=dict(good=good))
+        print(f"Record written: ts={ts}, good={good}")
+        good = not good
+        await asyncio.sleep(1)
+
+
+async def subscriber():
+    """Subscribe on good records and exit after ten received"""
+    global running
+    bucket: Bucket = await client.create_bucket("bucket", exist_ok=True)
+    counter = 0
+    async for record in bucket.subscribe(
+        "entry-1", start=int(time_ns() / 10000), include=dict(good=True)
+    ):
+        print(f"Good record received: ts={record.timestamp}, labels={record.labels}")
+        counter += 1
+        if counter >= 10:
+            running = False
+            break
+
+
+if __name__ == "__main__":
+    loop = asyncio.new_event_loop()
+
+    loop.create_task(writer())
+    loop.create_task(subscriber())
+    while running:
+        loop.run_until_complete(asyncio.sleep(1))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,9 @@ docs_dir: .
 nav:
   - Home:
       - README.md
+  - Tutorials:
       - Quick Start: docs/quick-start.md
+      - Subscripting: docs/subscripting.md
   - API Reference:
       - Client: docs/api/client.md
       - Bucket: docs/api/bucket.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 [project]
 
 name = "reduct-py"
-version = "1.3.1"
+version = "1.4.0"
 description = "ReductStore Client SDK for Python"
 requires-python = ">=3.7"
 readme = "README.md"

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -338,7 +338,7 @@ class Bucket:
             >>>         print(chunk)
         """
         query_id = await self._query(
-            entry_name, start, None, poll_interval * 2, continuous=True, **kwargs
+            entry_name, start, None, poll_interval * 2 + 1, continuous=True, **kwargs
         )
         while True:
             async with self._http.request(

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -199,9 +199,8 @@ async def test__get_token_with_error(client):
 async def test__list_tokens(client, with_token):
     """Should list all tokens"""
     tokens = await client.get_token_list()
-    assert len(tokens) == 2
-    assert tokens[0].name == "init-token"
-    assert tokens[1].name == with_token
+    assert len(tokens) == 1
+    assert tokens[0].name == with_token
 
 
 @requires_env("RS_API_TOKEN")


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

Since 1.4 ReductStore supports continuous queries which work as subscriptions.  However, the SDK doesn't support this feature.

### What is the new behavior?

I added method `Bucket.subscribe` and a tutorial with a usage example. 

### Does this PR introduce a breaking change?

No

### Other information:
