### PR TITLE
Use only integers for timestamps in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Subscribing to new records, [PR-70](https://github.com/reductstore/reduct-py/pull/70)
 
+### Fixed:
+
+- No int timestamps in queries, [PR-73](https://github.com/reductstore/reduct-py/pull/73)
+
 ## [1.3.1] - 2023-01-30
 
 ### Fixed:

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -126,7 +126,7 @@ def _parse_record(resp, last=True):
     size = int(resp.headers["content-length"])
     content_type = resp.headers.get("content-type", "application/octet-stream")
     labels = dict(
-        (name[len(LABEL_PREFIX):], value)
+        (name[len(LABEL_PREFIX) :], value)
         for name, value in resp.headers.items()
         if name.startswith(LABEL_PREFIX)
     )
@@ -199,7 +199,7 @@ class Bucket:
 
     @asynccontextmanager
     async def read(
-            self, entry_name: str, timestamp: Optional[int] = None
+        self, entry_name: str, timestamp: Optional[int] = None
     ) -> AsyncIterator[Record]:
         """
         Read a record from entry
@@ -217,17 +217,17 @@ class Bucket:
         """
         params = {"ts": int(timestamp)} if timestamp else None
         async with self._http.request(
-                "GET", f"/b/{self.name}/{entry_name}", params=params
+            "GET", f"/b/{self.name}/{entry_name}", params=params
         ) as resp:
             yield _parse_record(resp)
 
     async def write(
-            self,
-            entry_name: str,
-            data: Union[bytes, AsyncIterator[bytes]],
-            timestamp: Optional[int] = None,
-            content_length: Optional[int] = None,
-            **kwargs,
+        self,
+        entry_name: str,
+        data: Union[bytes, AsyncIterator[bytes]],
+        timestamp: Optional[int] = None,
+        content_length: Optional[int] = None,
+        **kwargs,
     ):
         """
         Write a record to entry
@@ -268,12 +268,12 @@ class Bucket:
         )
 
     async def query(
-            self,
-            entry_name: str,
-            start: Optional[int] = None,
-            stop: Optional[int] = None,
-            ttl: Optional[int] = None,
-            **kwargs,
+        self,
+        entry_name: str,
+        start: Optional[int] = None,
+        stop: Optional[int] = None,
+        ttl: Optional[int] = None,
+        **kwargs,
     ) -> AsyncIterator[Record]:
         """
         Query data for a time interval
@@ -300,7 +300,7 @@ class Bucket:
         last = False
         while not last:
             async with self._http.request(
-                    "GET", f"/b/{self.name}/{entry_name}?q={query_id}"
+                "GET", f"/b/{self.name}/{entry_name}?q={query_id}"
             ) as resp:
                 if resp.status == 204:
                     return
@@ -316,7 +316,7 @@ class Bucket:
         )
 
     async def subscribe(
-            self, entry_name: str, start: Optional[int] = None, poll_interval=1.0, **kwargs
+        self, entry_name: str, start: Optional[int] = None, poll_interval=1.0, **kwargs
     ) -> AsyncIterator[Record]:
         """
         Query records from the start timestamp and wait for new records
@@ -343,7 +343,7 @@ class Bucket:
         )
         while True:
             async with self._http.request(
-                    "GET", f"/b/{self.name}/{entry_name}?q={query_id}"
+                "GET", f"/b/{self.name}/{entry_name}?q={query_id}"
             ) as resp:
                 if resp.status == 204:
                     await asyncio.sleep(poll_interval)

--- a/reduct/http.py
+++ b/reduct/http.py
@@ -53,7 +53,6 @@ class HttpClient:
                     headers=dict(self.headers, **extra_headers),
                     **kwargs,
                 ) as response:
-
                     if response.ok:
                         yield response
                     else:

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -117,6 +117,7 @@ async def test__write_by_timestamp(bucket_2):
 async def test__write_with_current_time(bucket_2):
     """Should write a record with current time"""
     belated_timestamp = int(time.time_ns() / 1000)
+    await asyncio.sleep(0.01)
 
     await bucket_2.write("entry-3", b"test-data")
     await bucket_2.write("entry-3", b"old-data", timestamp=belated_timestamp)
@@ -174,12 +175,10 @@ async def test_query_records(bucket_1):
     assert records[0].timestamp == 3000000
     assert records[0].size == 11
     assert records[0].content_type == "application/octet-stream"
-    assert not records[0].last
 
     assert records[1].timestamp == 4000000
     assert records[1].size == 11
     assert records[1].content_type == "application/octet-stream"
-    assert records[1].last
 
 
 @pytest.mark.asyncio
@@ -212,7 +211,6 @@ async def test_query_records_included_labels(bucket_1):
 
     assert len(records) == 1
     assert records[0].labels == {"label1": "value1", "label2": "value2"}
-    assert records[0].last
 
 
 @pytest.mark.asyncio
@@ -233,7 +231,6 @@ async def test_query_records_excluded_labels(bucket_2):
 
     assert len(records) == 1
     assert records[0].labels == {"label1": "value1", "label2": "value3"}
-    assert records[0].last
 
 
 @pytest.mark.asyncio

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -48,7 +48,7 @@ async def test__bad_url_server_exists():
 
     with pytest.raises(ReductError) as reduct_err:
         await client.info()
-    assert str(reduct_err.value) == ("Status 404: Not Found")
+    assert str(reduct_err.value) == ("Status 404: Not found")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fixes

### What is the current behavior?

Rust implementation is stricter and doesn't allow floats for timestamps

### What is the new behavior?

I added casting to int into queries


### Does this PR introduce a breaking change?

No

### Other information:
