### PR TITLE
Use Expect: 100-continue for large files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 
 - No int timestamps in queries, [PR-73](https://github.com/reductstore/reduct-py/pull/73)
+- Use Expect: 100-continue for large files, [PR-75](https://github.com/reductstore/reduct-py/pull/75)
 
 ## [1.3.1] - 2023-01-30
 

--- a/reduct/http.py
+++ b/reduct/http.py
@@ -31,8 +31,14 @@ class HttpClient:
         """HTTP request with ReductError exception"""
 
         extra_headers = {}
+
         if "content_length" in kwargs:
-            extra_headers["Content-Length"] = str(kwargs["content_length"])
+            content_length = kwargs["content_length"]
+            extra_headers["Content-Length"] = str(content_length)
+            if content_length > 256_000:
+                # Use 100-continue for large files
+                extra_headers["Expect"] = "100-continue"
+
             del kwargs["content_length"]
 
         if "content_type" in kwargs:

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -164,6 +164,14 @@ async def test__write_with_content_type(bucket_1):
 
 
 @pytest.mark.asyncio
+async def test_write_big_blob(bucket_1):
+    """Should write big blob and stop upload if http status is not 200"""
+    await bucket_1.write("entry-1", b"1" * 1000000, timestamp=1)
+    with pytest.raises(ReductError, match="409"):
+        await bucket_1.write("entry-1", b"1" * 10_000_000, timestamp=1)
+
+
+@pytest.mark.asyncio
 async def test_query_records(bucket_1):
     """Should query records for a time interval"""
     records: List[Record] = [


### PR DESCRIPTION
Closes #74 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #74

### What is the new behavior?

If a client writes a record bigger than 256KB , it uses the Expect header, to receive HTTP 100 status or an error, before starting to upload it.

### Does this PR introduce a breaking change?

No

### Other information:
