### PR TITLE
Force close connection after each request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- Force close connection after each request to avoid
+  ServerDisconnectedError, [PR-77](https://github.com/reductstore/reduct-py/pull/77)
+
 ## [1.4.0] - 2023-05-29
 
 ### Added:

--- a/examples/subscribing.py
+++ b/examples/subscribing.py
@@ -26,6 +26,7 @@ async def subscriber():
     global running
     bucket: Bucket = await client.create_bucket("bucket", exist_ok=True)
     counter = 0
+    await asyncio.sleep(1)
     async for record in bucket.subscribe(
         "entry-1",
         start=int(time_ns() / 10000),


### PR DESCRIPTION
Closes #76 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #76 

### What is the new behavior?

Sending "Connection: close" works slower than a custom connector with `force_close` flag.

### Does this PR introduce a breaking change?

No

### Other information:
