### PR TITLE
Implement batching records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- Supports for batched records, [PR-78](https://github.com/reductstore/reduct-py/pull/78)
+
 ## [1.4.1] - 2023-06-05
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ This package provides an asynchronous HTTP client for interacting with the [Redu
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.4](https://docs.reduct.store/http-api)
+* Supports the [ReductStore HTTP API v1.5](https://docs.reduct.store/http-api)
 * Bucket management
 * API Token management
 * Write, read and query data
 * Labels
+* Batching records
 * Subscription on new data
 
 ## Install

--- a/docs/api/record.md
+++ b/docs/api/record.md
@@ -1,0 +1,2 @@
+::: reduct.Record
+    handler: python

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -31,7 +31,7 @@ interact with the ReductStore service.
 Here is an example of using the Python SDK to perform a few different operations on a bucket:
 
 ```python title="quick_start.py"
---8<-- "../examples/quick_start.py:"
+--8<--"../examples/quick_start.py:"
 ```
 
 Let's break down what this example is doing.
@@ -42,7 +42,7 @@ To create a ReductStore client, you can use the `Client` class from the `reduct`
 instance you want to connect to as an argument to the `Client` constructor:
 
 ```python title="quick_start.py"
---8<-- "../examples/quick_start.py:createclient"
+--8<--"../examples/quick_start.py:createclient"
 ```
 
 
@@ -53,7 +53,7 @@ want to get or create as an argument, along with a `BucketSettings` object to sp
 Set the `exist_ok` argument to True to create the bucket if it does not exist:
 
 ```python title="quick_start.py"
---8<-- "../examples/quick_start.py:createbucket"
+--8<--"../examples/quick_start.py:createbucket"
 ```
 
 ### Writing data to a Bucket
@@ -63,7 +63,7 @@ Pass the name of the entry you want to write to as an argument, along with the d
 will automatically use the current timestamp when writing the data to the entry:
 
 ```python title="quick_start.py"
---8<-- "../examples/quick_start.py:writedata"
+--8<--"../examples/quick_start.py:writedata"
 ```
 
 This is the simplest case for writing data to an entry in a bucket using the SDK. The write method also allows
@@ -75,7 +75,7 @@ Specify the total size of the file with the `content_length` argument, and speci
 argument:
 
 ```python title="quick_start.py"
---8<-- "../examples/quick_start.py:uploadfile"
+--8<--"../examples/quick_start.py:uploadfile"
 ```
 
 This code snippet shows how to use the write method to upload a file in chunks to an entry in a bucket. The generator
@@ -89,7 +89,7 @@ want to read from and the timestamp of the specific record you want to read as a
 to open the record, and then use the `read_all` method to read all of the data in the record:
 
 ```python title="quick_start.py"
---8<-- "../examples/quick_start.py:readdata"
+--8<--"../examples/quick_start.py:readdata"
 ```
 
 To iterate over all records in an entry, you can use the `query` method on a Bucket instance. Pass the name of the entry
@@ -97,7 +97,7 @@ you want to iterate over as an argument. Use a for loop to iterate over the reco
 record to read the data in chunks:
 
 ```python title="quick_start.py"
---8<-- "../examples/quick_start.py:iteraterecords"
+--8<--"../examples/quick_start.py:iteraterecords"
 ```
 
 The `query` method returns an async iterator to the records in the entry. By default, the method returns all records

--- a/docs/subscribing.md
+++ b/docs/subscribing.md
@@ -31,13 +31,13 @@ When the `subscriber` will receive 10 records, it stops the subscription and the
 This is the whole script:
 
 ```python title="subscribing.py"
---8<-- "../examples/subscribing.py:"
+--8<--"../examples/subscribing.py:"
 ```
 
 The most important part of the script is the `subscriber` coroutine:
 
 ```python title="subscribing.py"
---8<-- "../examples/subscribing.py:subscriber"
+--8<--"../examples/subscribing.py:subscriber"
 ```
 
 The `subcribe` method queries records from the `entry-1` entry from the current time and subscribes to new records that have

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - API Reference:
       - Client: docs/api/client.md
       - Bucket: docs/api/bucket.md
+      - Record: docs/api/record.md
       - ReductError: docs/api/reduct_error.md
       - ServerInfo: docs/api/server_info.md
       - BucketInfo: docs/api/bucket_info.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,4 +64,4 @@ asyncio_mode = "strict"
 [tool.pylint]
 max-line-length = 88
 extension-pkg-whitelist = "pydantic"
-good-names = "me"
+good-names = "me,n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 [project]
 
 name = "reduct-py"
-version = "1.4.1"
+version = "1.5.0"
 description = "ReductStore Client SDK for Python"
 requires-python = ">=3.7"
 readme = "README.md"

--- a/reduct/__init__.py
+++ b/reduct/__init__.py
@@ -1,4 +1,6 @@
 """Reduct module"""
+from reduct.record import Record
+
 from reduct.bucket import (
     QuotaType,
     Bucket,
@@ -6,7 +8,6 @@ from reduct.bucket import (
     BucketSettings,
     EntryInfo,
     BucketFullInfo,
-    Record,
 )
 
 from reduct.client import (

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -5,6 +5,7 @@ import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from enum import Enum
+from functools import partial
 from typing import (
     Optional,
     List,
@@ -18,6 +19,7 @@ from typing import (
 from pydantic import BaseModel
 
 from reduct.http import HttpClient
+from reduct.record import Record, parse_batched_records, parse_record
 
 
 class QuotaType(Enum):
@@ -95,51 +97,6 @@ class BucketFullInfo(BaseModel):
 
     entries: List[EntryInfo]
     """information about entries of bucket"""
-
-
-@dataclass
-class Record:
-    """Record in a query"""
-
-    timestamp: int
-    """UNIX timestamp in microseconds"""
-    size: int
-    """size of data"""
-    last: bool
-    """last record in the query. Deprecated: doesn't work for some cases"""
-    content_type: str
-    """content type of data"""
-    read_all: Callable[[None], Awaitable[bytes]]
-    """read all data"""
-    read: Callable[[int], AsyncIterator[bytes]]
-    """read data in chunks"""
-
-    labels: Dict[str, str]
-    """labels of record"""
-
-
-LABEL_PREFIX = "x-reduct-label-"
-
-
-def _parse_record(resp, last=True):
-    timestamp = int(resp.headers["x-reduct-time"])
-    size = int(resp.headers["content-length"])
-    content_type = resp.headers.get("content-type", "application/octet-stream")
-    labels = dict(
-        (name[len(LABEL_PREFIX) :], value)
-        for name, value in resp.headers.items()
-        if name.startswith(LABEL_PREFIX)
-    )
-
-    return Record(
-        timestamp=timestamp,
-        size=size,
-        last=last,
-        read_all=resp.read,
-        read=resp.content.iter_chunked,
-        labels=labels,
-        content_type=content_type,
-    )
 
 
 class Bucket:
@@ -298,14 +255,26 @@ class Bucket:
         """
         query_id = await self._query(entry_name, start, stop, ttl, **kwargs)
         last = False
-        while not last:
-            async with self._http.request(
-                "GET", f"/b/{self.name}/{entry_name}?q={query_id}"
-            ) as resp:
-                if resp.status == 204:
-                    return
-                last = int(resp.headers["x-reduct-last"]) != 0
-                yield _parse_record(resp, last)
+
+        if self._http.api_version and self._http.api_version >= "1.5":
+            while not last:
+                async with self._http.request(
+                    "GET", f"/b/{self.name}/{entry_name}/batch?q={query_id}"
+                ) as resp:
+                    if resp.status == 204:
+                        return
+                    async for record in parse_batched_records(resp):
+                        last = record.last
+                        yield record
+        else:
+            while not last:
+                async with self._http.request(
+                    "GET", f"/b/{self.name}/{entry_name}?q={query_id}"
+                ) as resp:
+                    if resp.status == 204:
+                        return
+                    last = int(resp._headers["x-reduct-last"]) != 0
+                    yield parse_record(resp, last)
 
     async def get_full_info(self) -> BucketFullInfo:
         """
@@ -341,15 +310,28 @@ class Bucket:
         query_id = await self._query(
             entry_name, start, None, poll_interval * 2 + 1, continuous=True, **kwargs
         )
-        while True:
-            async with self._http.request(
-                "GET", f"/b/{self.name}/{entry_name}?q={query_id}"
-            ) as resp:
-                if resp.status == 204:
-                    await asyncio.sleep(poll_interval)
-                    continue
 
-                yield _parse_record(resp, False)
+        if self._http.api_version and self._http.api_version >= "1.5":
+            while True:
+                async with self._http.request(
+                    "GET", f"/b/{self.name}/{entry_name}/batch?q={query_id}"
+                ) as resp:
+                    if resp.status == 204:
+                        await asyncio.sleep(poll_interval)
+                        continue
+
+                    async for record in parse_batched_records(resp):
+                        yield record
+        else:
+            while True:
+                async with self._http.request(
+                    "GET", f"/b/{self.name}/{entry_name}?q={query_id}"
+                ) as resp:
+                    if resp.status == 204:
+                        await asyncio.sleep(poll_interval)
+                        continue
+
+                    yield parse_record(resp, False)
 
     async def _query(self, entry_name, start, stop, ttl, **kwargs):
         params = {}

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -320,7 +320,7 @@ class Bucket:
                         await asyncio.sleep(poll_interval)
                         continue
 
-                    async for record in parse_batched_records(resp):
+                    for record in parse_batched_records(resp):
                         yield record
         else:
             while True:

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -3,17 +3,12 @@ import asyncio
 import json
 import time
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
 from enum import Enum
-from functools import partial
 from typing import (
     Optional,
     List,
     AsyncIterator,
     Union,
-    Callable,
-    Awaitable,
-    Dict,
 )
 
 from pydantic import BaseModel
@@ -176,7 +171,7 @@ class Bucket:
         async with self._http.request(
             "GET", f"/b/{self.name}/{entry_name}", params=params
         ) as resp:
-            yield _parse_record(resp)
+            yield parse_record(resp)
 
     async def write(
         self,
@@ -273,7 +268,7 @@ class Bucket:
                 ) as resp:
                     if resp.status == 204:
                         return
-                    last = int(resp._headers["x-reduct-last"]) != 0
+                    last = int(resp.headers["x-reduct-last"]) != 0
                     yield parse_record(resp, last)
 
     async def get_full_info(self) -> BucketFullInfo:
@@ -320,7 +315,7 @@ class Bucket:
                         await asyncio.sleep(poll_interval)
                         continue
 
-                    for record in parse_batched_records(resp):
+                    async for record in parse_batched_records(resp):
                         yield record
         else:
             while True:

--- a/reduct/record.py
+++ b/reduct/record.py
@@ -1,0 +1,132 @@
+"""Record representation and its parsing"""
+from dataclasses import dataclass
+from functools import partial
+from typing import List, Dict, Callable, AsyncIterator, Awaitable
+
+from aiohttp import ClientResponse
+
+
+@dataclass
+class Record:
+    """Record in a query"""
+
+    timestamp: int
+    """UNIX timestamp in microseconds"""
+    size: int
+    """size of data"""
+    last: bool
+    """last record in the query. Deprecated: doesn't work for some cases"""
+    content_type: str
+    """content type of data"""
+    read_all: Callable[[None], Awaitable[bytes]]
+    """read all data"""
+    read: Callable[[int], AsyncIterator[bytes]]
+    """read data in chunks"""
+
+    labels: Dict[str, str]
+    """labels of record"""
+
+
+LABEL_PREFIX = "x-reduct-label-"
+
+
+def parse_record(resp: ClientResponse, last=True) -> Record:
+    """Parse record from response"""
+    timestamp = int(resp.headers["x-reduct-time"])
+    size = int(resp.headers["content-length"])
+    content_type = resp.headers.get("content-type", "application/octet-stream")
+    labels = dict(
+        (name[len(LABEL_PREFIX) :], value)
+        for name, value in resp.headers.items()
+        if name.startswith(LABEL_PREFIX)
+    )
+
+    return Record(
+        timestamp=timestamp,
+        size=size,
+        last=last,
+        read_all=resp.read,
+        read=resp.content.iter_chunked,
+        labels=labels,
+        content_type=content_type,
+    )
+
+
+async def parse_batched_records(resp: ClientResponse) -> AsyncIterator[Record]:
+    def parse_csv_row(row: str):
+        items = []
+        escaped = ""
+        for item in row.split(","):
+            if item.startswith('"') and not escaped:
+                escaped = item[1:]
+            if escaped:
+                if item.endswith('"'):
+                    escaped = escaped[:-1]
+                    items.append(escaped)
+                    escaped = ""
+                else:
+                    escaped += item
+            else:
+                items.append(item)
+
+        data = dict(labels={})
+        for item in items:
+            kv = item.split("=", 1)
+
+            if kv[0].startswith("label-"):
+                data["labels"][kv[0][6:]] = kv[1]
+            else:
+                data[kv[0]] = kv[1]
+
+        return data
+
+    records_total = sum(
+        1 for header in resp.headers if header.startswith("x-reduct-time-")
+    )
+    records_count = 0
+    read_counter = [0]
+    global_offset = 0
+    for k, v in resp.headers.items():
+        if k.startswith("x-reduct-time-"):
+            timestamp = int(k[14:])
+            meta_data = parse_csv_row(v)
+
+            content_length = int(meta_data["content-length"])
+
+            async def read(offset, n):
+                if read_counter[0] != offset:
+                    raise RuntimeError("Read batched records out of order")
+                count = 0
+                n = min(n, content_length)
+                async for chunk in resp.content.iter_chunked(n):
+                    read_counter[0] += len(chunk)
+                    count += len(chunk)
+                    n = min(n, content_length - count)
+                    yield chunk
+
+                    if count == content_length:
+                        break
+
+            async def read_all(offset):
+                data = b""
+                async for chunk in read(offset, 512_000):
+                    data += chunk
+                return data
+
+            record = Record(
+                timestamp=timestamp,
+                size=content_length,
+                last=False,
+                content_type=meta_data["content-type"],
+                labels=meta_data["labels"],
+                read_all=partial(read_all, global_offset),
+                read=partial(read, global_offset),
+            )
+
+            global_offset += content_length
+            records_count += 1
+            if records_count == records_total:
+                if resp.headers.get("x-reduct-last", "false") == "true":
+                    record.last = True
+
+            yield record

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -1,7 +1,7 @@
 """Tests for Bucket"""
 import asyncio
 import time
-from typing import List
+from typing import List, Tuple
 
 import pytest
 
@@ -174,19 +174,21 @@ async def test_write_big_blob(bucket_1):
 @pytest.mark.asyncio
 async def test_query_records(bucket_1):
     """Should query records for a time interval"""
-    records: List[Record] = [
-        record
+    records: List[Tuple[Record, bytes]] = [
+        (record, await record.read_all())
         async for record in bucket_1.query("entry-2", start=0, stop=5_000_000, ttl=5)
     ]
     assert len(records) == 2
 
-    assert records[0].timestamp == 3000000
-    assert records[0].size == 11
-    assert records[0].content_type == "application/octet-stream"
+    assert records[0][0].timestamp == 3000000
+    assert records[0][0].size == 11
+    assert records[0][0].content_type == "application/octet-stream"
+    assert records[0][1] == b"some-data-3"
 
-    assert records[1].timestamp == 4000000
-    assert records[1].size == 11
-    assert records[1].content_type == "application/octet-stream"
+    assert records[1][0].timestamp == 4000000
+    assert records[1][0].size == 11
+    assert records[1][0].content_type == "application/octet-stream"
+    assert records[1][1] == b"some-data-4"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

Since v1.5, ReductStore provides the `GET /v1/api/:bucket/:entry/batch` endpoint to batch multiple records into a response, so that we can reduce the HTTP overhead for reading many small records, but this feature isn't supported in the Python SDK.

### What is the new behavior?

I integrated this feature, the client uses it when it figures out that the API version is v1.5.

### Does this PR introduce a breaking change?

No

### Other information:
