### PR TITLE
Fix unordered reading batched records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Supports for batched records, [PR-78](https://github.com/reductstore/reduct-py/pull/78)
 - `extra_headers` to Client constructor, [PR-81](https://github.com/reductstore/reduct-py/pull/81)
 
+### Fixed:
+
+- Unordered reading batched records, [PR-82](https://github.com/reductstore/reduct-py/pull/82)
+
 ## [1.4.1] - 2023-06-05
 
 ### Fixed:

--- a/reduct/record.py
+++ b/reduct/record.py
@@ -29,6 +29,7 @@ class Record:
 
 
 LABEL_PREFIX = "x-reduct-label-"
+CHUNK_SIZE = 512_000
 
 
 def parse_record(resp: ClientResponse, last=True) -> Record:
@@ -88,30 +89,26 @@ async def parse_batched_records(resp: ClientResponse) -> AsyncIterator[Record]:
         1 for header in resp.headers if header.startswith("x-reduct-time-")
     )
     records_count = 0
-    read_counter = [0]
-    global_offset = 0
 
-    async def read(offset, size, n):
-        if read_counter[0] != offset:
-            raise RuntimeError(
-                f"Read batched records out of order: {read_counter[0]} != {offset}"
-            )
+    async def read(buffer: bytes, n: int):
         count = 0
+        size = len(buffer)
         n = min(n, size)
 
         while True:
-            chunk = await resp.content.read(n)
-            read_counter[0] += len(chunk)
+            chunk = buffer[count : count + n]
             count += len(chunk)
             n = min(n, size - count)
             yield chunk
 
+            await asyncio.sleep(0)
+
             if count == size:
                 break
 
-    async def read_all(offset, size):
+    async def read_all(buffer):
         data = b""
-        async for chunk in read(offset, size, 512_000):
+        async for chunk in read(buffer, CHUNK_SIZE):
             data += chunk
         return data
 
@@ -121,21 +118,44 @@ async def parse_batched_records(resp: ClientResponse) -> AsyncIterator[Record]:
             meta_data = _parse_csv_row(value)
             content_length = int(meta_data["content-length"])
 
+            last = False
+            records_count += 1
+
+            if records_count == records_total:
+                # last record in batched records read in client code
+                read_func = resp.content.iter_chunked
+                read_all_func = resp.read
+                if resp.headers.get("x-reduct-last", "false") == "true":
+                    # last record in query
+                    last = True
+            else:
+                # batched records must be read in order, so it is safe to read them here
+                # instead of reading them in the use code with an async interator.
+                # The batched records are small if they are not the last.
+                # The last batched record is read in the async generator in chunks.
+                buffer = b""
+                count = 0
+
+                while True:
+                    n = min(CHUNK_SIZE, content_length - count)
+                    chunk = await resp.content.read(n)
+                    buffer += chunk
+                    count += len(chunk)
+
+                    if count == content_length:
+                        break
+
+                read_func = partial(read, buffer)
+                read_all_func = partial(read_all, buffer)
+
             record = Record(
                 timestamp=timestamp,
                 size=content_length,
-                last=False,
+                last=last,
                 content_type=meta_data["content-type"],
                 labels=meta_data["labels"],
-                read_all=partial(read_all, global_offset, content_length),
-                read=partial(read, global_offset, content_length),
+                read_all=read_all_func,
+                read=read_func,
             )
 
-            global_offset += content_length
-            records_count += 1
-            if records_count == records_total:
-                if resp.headers.get("x-reduct-last", "false") == "true":
-                    record.last = True
-
             yield record
-            await asyncio.sleep(0)

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -1,7 +1,6 @@
 """Tests for Bucket"""
 import asyncio
 import time
-from hashlib import md5
 
 from typing import List, Tuple
 
@@ -337,9 +336,9 @@ async def test_read_batched_records_in_random_order_chunks(bucket_1, size):
     await bucket_1.write("entry-3", b"2" * size, timestamp=2)
     await bucket_1.write("entry-3", b"3" * size, timestamp=3)
 
-    async def read_chunks(r: Record):
+    async def read_chunks(rec: Record):
         buffer = b""
-        async for chunk in r.read(1024):
+        async for chunk in rec.read(1024):
             buffer += chunk
         return buffer
 


### PR DESCRIPTION
Closes #79 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #79 

### What is the new behavior?

I read all the records except for the last one in the query, where the records were guaranteed to be in the right order. The last one may be a big blob, and it is necessary to provide an option to read it as an asynchronous iterator in the client code. Because it is the last record and all the previous records are read, it is safe to provide the asynchronous iterator outside the query method.

### Does this PR introduce a breaking change?

No

### Other information:
