### PR TITLE
Add `head` option for reading only metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
-- Supports for batched records, [PR-78](https://github.com/reductstore/reduct-py/pull/78)
+- Support for batched records, [PR-78](https://github.com/reductstore/reduct-py/pull/78)
 - `extra_headers` to Client constructor, [PR-81](https://github.com/reductstore/reduct-py/pull/81)
 
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for batched records, [PR-78](https://github.com/reductstore/reduct-py/pull/78)
 - `extra_headers` to Client constructor, [PR-81](https://github.com/reductstore/reduct-py/pull/81)
+- `head` option to `Bucket.query` and `Bucket.read` to read only metadata, [PR-83](https://github.com/reductstore/reduct-py/pull/83)
 
 ### Fixed:
 

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -227,7 +227,6 @@ class Bucket:
         start: Optional[int] = None,
         stop: Optional[int] = None,
         ttl: Optional[int] = None,
-        head: bool = False,
         **kwargs,
     ) -> AsyncIterator[Record]:
         """
@@ -238,10 +237,10 @@ class Bucket:
             start: the beginning of the time interval
             stop: the end of the time interval
             ttl: Time To Live of the request in seconds
-            head: if True: get only the header of a recod with metadata
         Keyword Args:
             include (dict): query records which have all labels from this dict
-            exclude (dict): query records which doesn't have all labels from this dict
+            exclude (dict): query records which doesn't have all labels from this
+            head (bool): if True: get only the header of a recod with metadata
         Returns:
              AsyncIterator[Record]: iterator to the records
 
@@ -254,7 +253,7 @@ class Bucket:
         """
         query_id = await self._query(entry_name, start, stop, ttl, **kwargs)
         last = False
-        method = "HEAD" if head else "GET"
+        method = "HEAD" if "head" in kwargs and kwargs["head"] else "GET"
 
         if self._http.api_version and self._http.api_version >= "1.5":
             while not last:

--- a/reduct/record.py
+++ b/reduct/record.py
@@ -113,6 +113,7 @@ async def parse_batched_records(resp: ClientResponse) -> AsyncIterator[Record]:
         1 for header in resp.headers if header.startswith("x-reduct-time-")
     )
     records_count = 0
+    head = resp.method == "HEAD"
 
     for name, value in resp.headers.items():
         if name.startswith("x-reduct-time-"):
@@ -135,7 +136,10 @@ async def parse_batched_records(resp: ClientResponse) -> AsyncIterator[Record]:
                 # instead of reading them in the use code with an async interator.
                 # The batched records are small if they are not the last.
                 # The last batched record is read in the async generator in chunks.
-                buffer = await _read_response(resp, content_length)
+                if head:
+                    buffer = b""
+                else:
+                    buffer = await _read_response(resp, content_length)
                 read_func = partial(_read, buffer)
                 read_all_func = partial(_read_all, buffer)
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

ReductStore v1.5 supports for `HEAD` endpoints to read only metadata about records without the content. The Python SDK doesn't support it.

### What is the new behavior?

I've added the support with tests.

### Does this PR introduce a breaking change?

No

### Other information:
