### PR TITLE
Parse shorter header syntax for batched records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 
 - Minimum Python version is now 3.8, [PR-84](https://github.com/reductstore/reduct-py/pull/84)
+- Parse shorter header syntax for batched records, [PR-85](https://github.com/reductstore/reduct-py/pull/85)
 
 ## [1.4.1] - 2023-06-05
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

I've changed the syntax of headers for batched records here reductstore/reductstore#298. However, the SDK uses the initial one.

### What is the new behavior?

I've changed the parsing and now the SDK is compatible.

### Does this PR introduce a breaking change?

No

### Other information:
