### PR TITLE
Add `head` flag to `Bucket.subscribe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for batched records, [PR-78](https://github.com/reductstore/reduct-py/pull/78)
 - `extra_headers` to Client constructor, [PR-81](https://github.com/reductstore/reduct-py/pull/81)
 - `head` option to `Bucket.query` and `Bucket.read` to read only metadata, [PR-83](https://github.com/reductstore/reduct-py/pull/83)
+- `head` option to `Bucket.subscribe`, [PR-87](https://github.com/reductstore/reduct-py/pull/87)
 
 ### Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 
 - Minimum Python version is now 3.8, [PR-84](https://github.com/reductstore/reduct-py/pull/84)
-- Parse shorter header syntax for batched records, [PR-85](https://github.com/reductstore/reduct-py/pull/85)
+- Parse short header syntax for batched records, [PR-85](https://github.com/reductstore/reduct-py/pull/85)
 
 ## [1.4.1] - 2023-06-05
 

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -296,6 +296,7 @@ class Bucket:
         Keyword Args:
             include (dict): query records which have all labels from this dict
             exclude (dict): query records which doesn't have all labels from this dict
+            head (bool): if True: get only the header of a recod with metadata
         Returns:
              AsyncIterator[Record]: iterator to the records
 
@@ -310,10 +311,11 @@ class Bucket:
             entry_name, start, None, poll_interval * 2 + 1, continuous=True, **kwargs
         )
 
+        method = "HEAD" if "head" in kwargs and kwargs["head"] else "GET"
         if self._http.api_version and self._http.api_version >= "1.5":
             while True:
                 async with self._http.request(
-                    "GET", f"/b/{self.name}/{entry_name}/batch?q={query_id}"
+                    method, f"/b/{self.name}/{entry_name}/batch?q={query_id}"
                 ) as resp:
                     if resp.status == 204:
                         await asyncio.sleep(poll_interval)
@@ -324,7 +326,7 @@ class Bucket:
         else:
             while True:
                 async with self._http.request(
-                    "GET", f"/b/{self.name}/{entry_name}?q={query_id}"
+                    method, f"/b/{self.name}/{entry_name}?q={query_id}"
                 ) as resp:
                     if resp.status == 204:
                         await asyncio.sleep(poll_interval)


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature 

### What is the current behavior?

It is also possible to subscribe only to metadata of records, but the `Bucket.subscribe` doesn't implement the feature.

### What is the new behavior?

I've added the `head` flag.

### Does this PR introduce a breaking change?

No

### Other information:
