### PR TITLE
Update documentation link to new website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed:
+
+- docs: update link to new website, [PR-98](https://github.com/reductstore/reduct-py/pull/98)
+
 ## [1.7.1] - 2023-10-09
 
 ### Fix:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package provides an asynchronous HTTP client for interacting with the [Redu
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.7](https://docs.reduct.store/http-api)
+* Supports the [ReductStore HTTP API v1.7](https://reduct.store/docs/http-api)
 * Bucket management
 * API Token management
 * Write, read and query data
@@ -59,4 +59,4 @@ For more examples, see the [Quick Start](https://py.reduct.store/en/latest/docs/
 ## References
 
 * [Documentation](https://py.reduct.store/)
-* [ReductStore HTTP API](https://docs.reduct.store/http-api)
+* [ReductStore HTTP API](https://reduct.store/docs/http-api)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -122,5 +122,5 @@ async for record in bucket.query("entry-1", start=start_ts, stop=stop_ts):
 ## Next Steps
 
 You can find more detailed documentation and examples in [the Reference API section](./api/bucket.md). You can also
-refer to the [ReductStore HTTP API](https://docs.reduct.store/http-api) documentation for a complete reference
+refer to the [ReductStore HTTP API](https://reduct.store/docs/http-api) documentation for a complete reference
 of the available API calls.

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -59,7 +59,7 @@ async def test__get_info(bucket_2):
         "latest_record": 6000000,
         "name": "bucket-2",
         "oldest_record": 5000000,
-        "size": 22,
+        "size": 88,
         "is_provisioned": False,
     }
 
@@ -84,7 +84,7 @@ async def test__get_entries(bucket_1):
         "name": "entry-1",
         "oldest_record": 1000000,
         "record_count": 2,
-        "size": 22,
+        "size": 88,
     }
 
     assert entries[1].dict() == {
@@ -93,7 +93,7 @@ async def test__get_entries(bucket_1):
         "name": "entry-2",
         "oldest_record": 3000000,
         "record_count": 2,
-        "size": 22,
+        "size": 88,
     }
 
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -62,7 +62,7 @@ async def test__info(client):
     assert info.version >= "1.2.0"
     assert info.uptime >= 1
     assert info.bucket_count == 2
-    assert info.usage == 66
+    assert info.usage == 264
     assert info.oldest_record == 1_000_000
     assert info.latest_record == 6_000_000
 


### PR DESCRIPTION
With new website we need to change links from docs.reduct.store to reduct.store/docs