### PR TITLE
RS-45: Update client to support replication API

### DIFF
--- a/reduct/__init__.py
+++ b/reduct/__init__.py
@@ -17,6 +17,9 @@ from reduct.client import (
     Token,
     Permissions,
     FullTokenInfo,
+    ReplicationInfo,
+    ReplicationDetailInfo,
+    ReplicationSettings,
 )
 
 from reduct.error import ReductError

--- a/reduct/client.py
+++ b/reduct/client.py
@@ -94,6 +94,71 @@ class TokenCreateResponse(BaseModel):
     """token for authentication"""
 
 
+class ReplicationInfo(BaseModel):
+    """Replication information"""
+
+    name: str
+    is_provisioned: bool
+    is_active: bool
+    pending_records: int
+
+
+class ReplicationList(BaseModel):
+    """List of replications"""
+
+    replications: List[ReplicationInfo]
+
+
+class ReplicationDiagnosticsError(BaseModel):
+    count: int
+    last_message: str
+
+
+class ReplicationDiagnosticsDetail(BaseModel):
+    """Diagnostics information for replication"""
+
+    ok: int
+    errored: int
+    errors: Dict[int, ReplicationDiagnosticsError]
+
+
+class ReplicationDiagnostics(BaseModel):
+    """Detailed diagnostics for replication"""
+
+    hourly: ReplicationDiagnosticsDetail
+
+
+class ReplicationSettingsDetail(BaseModel):
+    """Settings for replication"""
+
+    src_bucket: str
+    dst_bucket: str
+    dst_host: str
+    entries: List[str]
+    include: Dict[str, str]
+    exclude: Dict[str, str]
+
+
+class ReplicationDetailInfo(BaseModel):
+    """Complete information about a replication"""
+
+    diagnostics: ReplicationDiagnostics
+    info: ReplicationInfo
+    settings: ReplicationSettingsDetail
+
+
+class ReplicationSettings(BaseModel):
+    """Settings for creating a replication"""
+
+    src_bucket: str
+    dst_bucket: str
+    dst_host: str
+    dst_token: str = ""
+    entries: List[str] = []
+    include: Dict[str, str] = {}
+    exclude: Dict[str, str] = {}
+
+
 class Client:
     """HTTP Client for Reduct Storage HTTP API"""
 
@@ -256,3 +321,73 @@ class Client:
         """
         body, _ = await self._http.request_all("GET", "/me")
         return FullTokenInfo.model_validate_json(body)
+
+    async def get_replications(self) -> List[ReplicationInfo]:
+        """
+        Get a list of replications
+        Returns:
+            List[ReplicationInfo]: List of replications with their statuses
+        Raises:
+            ReductError: if there is an HTTP error
+        """
+        body, _ = await self._http.request_all("GET", "/replications")
+        return ReplicationList.model_validate_json(body).replications
+
+    async def get_replication_detail(
+        self, replication_name: str
+    ) -> ReplicationDetailInfo:
+        """
+        Get detailed information about a replication
+        Args:
+            replication_name: Name of the replication to show details
+        Returns:
+            ReplicationDetailInfo: Detailed information about the replication
+        Raises:
+            ReductError: if there is an HTTP error
+        """
+        body, _ = await self._http.request_all(
+            "GET", f"/replications/{replication_name}"
+        )
+        return ReplicationDetailInfo.model_validate_json(body)
+
+    async def create_replication(
+        self, replication_name: str, settings: ReplicationSettings
+    ) -> None:
+        """
+        Create a new replication
+        Args:
+            replication_name: Name of the new replication
+            settings: Settings for the new replication
+        Raises:
+            ReductError: if there is an HTTP error
+        """
+        data = settings.model_dump_json()
+        await self._http.request_all(
+            "POST", f"/replications/{replication_name}", data=data
+        )
+
+    async def update_replication(
+        self, replication_name: str, settings: ReplicationSettings
+    ) -> None:
+        """
+        Update an existing replication
+        Args:
+            replication_name: Name of the replication to update
+            settings: New settings for the replication
+        Raises:
+            ReductError: if there is an HTTP error
+        """
+        data = settings.model_dump_json()
+        await self._http.request_all(
+            "PUT", f"/replications/{replication_name}", data=data
+        )
+
+    async def delete_replication(self, replication_name: str) -> None:
+        """
+        Delete a replication
+        Args:
+            replication_name: Name of the replication to delete
+        Raises:
+            ReductError: if there is an HTTP error
+        """
+        await self._http.request_all("DELETE", f"/replications/{replication_name}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 import pytest_asyncio
 import requests
 
-from reduct import Client, Bucket
+from reduct import Client, Bucket, ReplicationSettings
 
 
 def requires_env(key):
@@ -74,3 +74,41 @@ async def _bucket_2(client) -> Bucket:
     await bucket.write("entry-1", b"some-data-2", timestamp=6_000_000)
     yield bucket
     await bucket.remove()
+
+
+@pytest_asyncio.fixture(name="replication_1")
+async def _replication_1(client) -> str:
+    replication_name = "replication-1"
+    replication_settings = ReplicationSettings(
+        src_bucket="bucket-1",
+        dst_bucket="bucket-2",
+        dst_host="http://127.0.0.1:8383",
+    )
+    await client.create_replication(replication_name, replication_settings)
+    yield replication_name
+    await client.delete_replication(replication_name)
+
+
+@pytest_asyncio.fixture(name="replication_2")
+async def _replication_2(client) -> str:
+    replication_name = "replication-2"
+    replication_settings = ReplicationSettings(
+        src_bucket="bucket-1",
+        dst_bucket="bucket-2",
+        dst_host="http://127.0.0.1:8383",
+    )
+    await client.create_replication(replication_name, replication_settings)
+    yield replication_name
+    await client.delete_replication(replication_name)
+
+
+@pytest_asyncio.fixture(name="temporary_replication")
+async def _temporary_replication(client) -> str:
+    replication_name = "temp-replication"
+    replication_settings = ReplicationSettings(
+        src_bucket="bucket-1",
+        dst_bucket="bucket-2",
+        dst_host="http://127.0.0.1:8383",
+    )
+    await client.create_replication(replication_name, replication_settings)
+    yield replication_name


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

feature

### What is the current behavior?

Before this PR, the code did not have support for ReductStorer HTTP API v1.8 replication endpoints, and users could not perform replication operations using the API.

### What is the new behavior?

The code now includes support for ReductStorer HTTP API v1.8 replication endpoints. Users can use these endpoints to create, update, get information, and delete replications.

### Does this PR introduce a breaking change?

no

### Other information:
