### PR TITLE
Remove duplicated ReplicationDetailSettings

### DIFF
--- a/reduct/client.py
+++ b/reduct/client.py
@@ -130,25 +130,6 @@ class ReplicationDiagnostics(BaseModel):
     hourly: ReplicationDiagnosticsDetail
 
 
-class ReplicationSettingsDetail(BaseModel):
-    """Settings for replication"""
-
-    src_bucket: str
-    dst_bucket: str
-    dst_host: str
-    entries: List[str]
-    include: Dict[str, str]
-    exclude: Dict[str, str]
-
-
-class ReplicationDetailInfo(BaseModel):
-    """Complete information about a replication"""
-
-    diagnostics: ReplicationDiagnostics
-    info: ReplicationInfo
-    settings: ReplicationSettingsDetail
-
-
 class ReplicationSettings(BaseModel):
     """Settings for creating a replication"""
 
@@ -159,6 +140,14 @@ class ReplicationSettings(BaseModel):
     entries: List[str] = []
     include: Dict[str, str] = {}
     exclude: Dict[str, str] = {}
+
+
+class ReplicationDetailInfo(BaseModel):
+    """Complete information about a replication"""
+
+    diagnostics: ReplicationDiagnostics
+    info: ReplicationInfo
+    settings: ReplicationSettings
 
 
 class Client:


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

We have `ReplicationSettings` and `ReplicationDetailSettings`. We need only the first one. 

### What is the new behavior?

I've removed `ReplicationDetailSettings`

### Does this PR introduce a breaking change?

Yes, the class wasn't a part of public import, but it was used by the `ReplicationDiagnostics` structure.

### Other information:
