### PR TITLE
RS-176: Add `license` field to  ServerInfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11"]
         reductstore_version: ["latest", "main"]
         token: ["", "ACCESS_TOKEN"]
-        license: ["", "lic.key"]
+        license: ["", "/workdir/lic.key"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@master
@@ -90,13 +90,17 @@ jobs:
         run: pip3 install .[test]
 
       - name: Generate license
-        run: echo ${{secrets.LICENSE_KEY}} > lic.key
+        run: echo '${{secrets.LICENSE_KEY}}' > lic.key
 
       - name: Run ReductStore
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{matrix.token}} --env RS_LOG_LEVEL=DEBUG --RS_LICENSE_PAT=${{matrix.license}} -d reduct/store:main
+        run: docker run -p 8383:8383 -v ${PWD}:/workdir 
+          --env RS_API_TOKEN=${{matrix.token}} 
+          --env RS_LOG_LEVEL=DEBUG 
+          --env RS_LICENSE_PATH=${{matrix.license}} 
+          -d reduct/store:main
 
       - name: Run Tests
-        run: PYTHONPATH=. RS_API_TOKEN=${{matrix.token}} pytest tests
+        run: PYTHONPATH=. RS_API_TOKEN=${{matrix.token}} RS_LICENSE_PATH=${{matrix.license}}  pytest tests
 
       - name: Dump docker logs on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11"]
         reductstore_version: ["latest", "main"]
         token: ["", "ACCESS_TOKEN"]
+        license: ["", "lic.key"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@master
@@ -88,8 +89,11 @@ jobs:
       - name: Install dependencies
         run: pip3 install .[test]
 
+      - name: Generate license
+        run: echo ${{secrets.LICENSE_KEY}} > lic.key
+
       - name: Run ReductStore
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{matrix.token}} --env RS_LOG_LEVEL=DEBUG -d reduct/store:main
+        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{matrix.token}} --env RS_LOG_LEVEL=DEBUG --RS_LICENSE_PAT=${{matrix.license}} -d reduct/store:main
 
       - name: Run Tests
         run: PYTHONPATH=. RS_API_TOKEN=${{matrix.token}} pytest tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8"]
         reductstore_version: ["latest", "main"]
         token: ["", "ACCESS_TOKEN"]
         license: ["", "/workdir/lic.key"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - RS-182: Add flag verify_ssl to Client, [PR-102](https://github.com/reductstore/reduct-py/pull/102)
+- RS-176: Add license field to ServerInfo, [PR-105](https://github.com/reductstore/reduct-py/pull/105)
 
 ## [1.8.1] - 2023-01-31
 

--- a/reduct/client.py
+++ b/reduct/client.py
@@ -17,6 +17,31 @@ class Defaults(BaseModel):
     """settings for a new bucket"""
 
 
+class LicenseInfo(BaseModel):
+    """License information"""
+
+    licensee: str
+    """Licensee usually is the company name"""
+
+    invoice: str
+    """Invoice number"""
+
+    expiry_date: datetime
+    """Expiry date of the license in ISO 8601 format (UTC)"""
+
+    plan: str
+    """Plan name"""
+
+    device_number: int
+    """Number of devices (0 for unlimited)"""
+
+    disk_quota: int
+    """Disk quota in TB (0 for unlimited)"""
+
+    fingerprint: str
+    """License fingerprint"""
+
+
 class ServerInfo(BaseModel):
     """Server stats"""
 
@@ -37,6 +62,9 @@ class ServerInfo(BaseModel):
 
     latest_record: int
     """UNIX timestamp of the latest record in microseconds"""
+
+    license: Optional[LicenseInfo] = None
+    """license information"""
 
     defaults: Defaults
     """Default server settings"""
@@ -154,12 +182,12 @@ class Client:
     """HTTP Client for Reduct Storage HTTP API"""
 
     def __init__(
-        self,
-        url: str,
-        api_token: Optional[str] = None,
-        timeout: Optional[float] = None,
-        extra_headers: Optional[Dict[str, str]] = None,
-        **kwargs,
+            self,
+            url: str,
+            api_token: Optional[str] = None,
+            timeout: Optional[float] = None,
+            extra_headers: Optional[Dict[str, str]] = None,
+            **kwargs,
     ):
         """
         Constructor
@@ -226,10 +254,10 @@ class Client:
         return Bucket(name, self._http)
 
     async def create_bucket(
-        self,
-        name: str,
-        settings: Optional[BucketSettings] = None,
-        exist_ok: bool = False,
+            self,
+            name: str,
+            settings: Optional[BucketSettings] = None,
+            exist_ok: bool = False,
     ) -> Bucket:
         """
         Create a new bucket
@@ -326,7 +354,7 @@ class Client:
         return ReplicationList.model_validate_json(body).replications
 
     async def get_replication_detail(
-        self, replication_name: str
+            self, replication_name: str
     ) -> ReplicationDetailInfo:
         """
         Get detailed information about a replication
@@ -343,7 +371,7 @@ class Client:
         return ReplicationDetailInfo.model_validate_json(body)
 
     async def create_replication(
-        self, replication_name: str, settings: ReplicationSettings
+            self, replication_name: str, settings: ReplicationSettings
     ) -> None:
         """
         Create a new replication
@@ -359,7 +387,7 @@ class Client:
         )
 
     async def update_replication(
-        self, replication_name: str, settings: ReplicationSettings
+            self, replication_name: str, settings: ReplicationSettings
     ) -> None:
         """
         Update an existing replication

--- a/reduct/client.py
+++ b/reduct/client.py
@@ -182,12 +182,12 @@ class Client:
     """HTTP Client for Reduct Storage HTTP API"""
 
     def __init__(
-            self,
-            url: str,
-            api_token: Optional[str] = None,
-            timeout: Optional[float] = None,
-            extra_headers: Optional[Dict[str, str]] = None,
-            **kwargs,
+        self,
+        url: str,
+        api_token: Optional[str] = None,
+        timeout: Optional[float] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        **kwargs,
     ):
         """
         Constructor
@@ -254,10 +254,10 @@ class Client:
         return Bucket(name, self._http)
 
     async def create_bucket(
-            self,
-            name: str,
-            settings: Optional[BucketSettings] = None,
-            exist_ok: bool = False,
+        self,
+        name: str,
+        settings: Optional[BucketSettings] = None,
+        exist_ok: bool = False,
     ) -> Bucket:
         """
         Create a new bucket
@@ -354,7 +354,7 @@ class Client:
         return ReplicationList.model_validate_json(body).replications
 
     async def get_replication_detail(
-            self, replication_name: str
+        self, replication_name: str
     ) -> ReplicationDetailInfo:
         """
         Get detailed information about a replication
@@ -371,7 +371,7 @@ class Client:
         return ReplicationDetailInfo.model_validate_json(body)
 
     async def create_replication(
-            self, replication_name: str, settings: ReplicationSettings
+        self, replication_name: str, settings: ReplicationSettings
     ) -> None:
         """
         Create a new replication
@@ -387,7 +387,7 @@ class Client:
         )
 
     async def update_replication(
-            self, replication_name: str, settings: ReplicationSettings
+        self, replication_name: str, settings: ReplicationSettings
     ) -> None:
         """
         Update an existing replication

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -83,17 +83,17 @@ async def test__info_with_license(client):
     info: ServerInfo = await client.info()
     assert info.license is not None
     assert info.license.model_dump() == {
-        'expires_at': '2022-12-31T23:59:59Z',
-        'max_buckets': 100,
-        'max_usage': 1000000000,
-        'type': 'trial',
-        'device_number': 1,
-        'disk_quota': 0,
-        'expiry_date': datetime(2035, 1, 1, 0, 0, tzinfo=timezone.utc),
-        'fingerprint': 'df92c95a7c9b56c2af99b290c39d8471c3e6cbf9dc33dc9bdb4116b98d465cc9',
-        'invoice': 'xxxxxx',
-        'licensee': 'ReductStore,LLC',
-        'plan': 'UNLIMITED',
+        "expires_at": "2022-12-31T23:59:59Z",
+        "max_buckets": 100,
+        "max_usage": 1000000000,
+        "type": "trial",
+        "device_number": 1,
+        "disk_quota": 0,
+        "expiry_date": datetime(2035, 1, 1, 0, 0, tzinfo=timezone.utc),
+        "fingerprint": "df92c95a7c9b56c2af99b290c39d8471c3e6cbf9dc33dc9bdb4116b98d465cc9",
+        "invoice": "xxxxxx",
+        "licensee": "ReductStore,LLC",
+        "plan": "UNLIMITED",
     }
 
 
@@ -184,7 +184,7 @@ async def test__create_token(client):
 async def test__create_token_with_error(client, with_token):
     """Should raise an error, if token exists"""
     with pytest.raises(
-            ReductError, match="Status 409: Token 'test-token' already exists"
+        ReductError, match="Status 409: Token 'test-token' already exists"
     ):
         await client.create_token(
             with_token, Permissions(full_access=True, read=[], write=[])
@@ -232,7 +232,7 @@ async def test__remove_token(client, with_token):
     """Should delete a token"""
     await client.remove_token(with_token)
     with pytest.raises(
-            ReductError, match="Status 404: Token 'test-token' doesn't exist"
+        ReductError, match="Status 404: Token 'test-token' doesn't exist"
     ):
         await client.get_token(with_token)
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -88,6 +88,7 @@ async def test__info_with_license(client):
         "max_usage": 1000000000,
     }
 
+
 @pytest.mark.asyncio
 async def test__list(client, bucket_1, bucket_2):
     """Should browse buckets"""

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,6 +1,5 @@
 """Tests for Client"""
 from asyncio import sleep
-from datetime import datetime, timezone
 from typing import List
 
 import pytest
@@ -84,7 +83,7 @@ async def test__info_with_license(client):
     assert info.license is not None
     assert info.license.device_number == 1
     assert info.license.disk_quota == 0
-    assert info.license.expiry_date.isoformat() == "2035-12-31T23:59:59+00:00"
+    assert info.license.expiry_date.isoformat() == "2035-01-01T00:00:00+00:00"
     assert (
         info.license.fingerprint
         == "df92c95a7c9b56c2af99b290c39d8471c3e6cbf9dc33dc9bdb4116b98d465cc9"

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -82,17 +82,16 @@ async def test__info_with_license(client):
     """Should get information about storage with license"""
     info: ServerInfo = await client.info()
     assert info.license is not None
-    assert info.license.model_dump() == {
-        "device_number": 1,
-        "disk_quota": 0,
-        "expiry_date": datetime.fromisoformat("2022-12-31T23:59:59+00:00").replace(
-            tzinfo=timezone.utc
-        ),
-        "fingerprint": "df92c95a7c9b56c2af99b290c39d8471c3e6cbf9dc33dc9bdb4116b98d465cc9",  # pylint: disable=line-too-long
-        "invoice": "xxxxxx",
-        "licensee": "ReductStore,LLC",
-        "plan": "UNLIMITED",
-    }
+    assert info.license.device_number == 1
+    assert info.license.disk_quota == 0
+    assert info.license.expiry_date.isoformat() == "2035-12-31T23:59:59+00:00"
+    assert (
+        info.license.fingerprint
+        == "df92c95a7c9b56c2af99b290c39d8471c3e6cbf9dc33dc9bdb4116b98d465cc9"
+    )
+    assert info.license.invoice == "xxxxxx"
+    assert info.license.licensee == "ReductStore,LLC"
+    assert info.license.plan == "UNLIMITED"
 
 
 @pytest.mark.asyncio

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,5 +1,6 @@
 """Tests for Client"""
 from asyncio import sleep
+from datetime import datetime, timezone
 from typing import List
 
 import pytest
@@ -82,10 +83,17 @@ async def test__info_with_license(client):
     info: ServerInfo = await client.info()
     assert info.license is not None
     assert info.license.model_dump() == {
-        "type": "trial",
-        "expires_at": "2022-12-31T23:59:59Z",
-        "max_buckets": 100,
-        "max_usage": 1000000000,
+        'expires_at': '2022-12-31T23:59:59Z',
+        'max_buckets': 100,
+        'max_usage': 1000000000,
+        'type': 'trial',
+        'device_number': 1,
+        'disk_quota': 0,
+        'expiry_date': datetime(2035, 1, 1, 0, 0, tzinfo=timezone.utc),
+        'fingerprint': 'df92c95a7c9b56c2af99b290c39d8471c3e6cbf9dc33dc9bdb4116b98d465cc9',
+        'invoice': 'xxxxxx',
+        'licensee': 'ReductStore,LLC',
+        'plan': 'UNLIMITED',
     }
 
 
@@ -176,7 +184,7 @@ async def test__create_token(client):
 async def test__create_token_with_error(client, with_token):
     """Should raise an error, if token exists"""
     with pytest.raises(
-        ReductError, match="Status 409: Token 'test-token' already exists"
+            ReductError, match="Status 409: Token 'test-token' already exists"
     ):
         await client.create_token(
             with_token, Permissions(full_access=True, read=[], write=[])
@@ -224,7 +232,7 @@ async def test__remove_token(client, with_token):
     """Should delete a token"""
     await client.remove_token(with_token)
     with pytest.raises(
-        ReductError, match="Status 404: Token 'test-token' doesn't exist"
+            ReductError, match="Status 404: Token 'test-token' doesn't exist"
     ):
         await client.get_token(with_token)
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -83,14 +83,12 @@ async def test__info_with_license(client):
     info: ServerInfo = await client.info()
     assert info.license is not None
     assert info.license.model_dump() == {
-        "expires_at": "2022-12-31T23:59:59Z",
-        "max_buckets": 100,
-        "max_usage": 1000000000,
-        "type": "trial",
         "device_number": 1,
         "disk_quota": 0,
-        "expiry_date": datetime(2035, 1, 1, 0, 0, tzinfo=timezone.utc),
-        "fingerprint": "df92c95a7c9b56c2af99b290c39d8471c3e6cbf9dc33dc9bdb4116b98d465cc9",
+        "expiry_date": datetime.fromisoformat("2022-12-31T23:59:59+00:00").replace(
+            tzinfo=timezone.utc
+        ),
+        "fingerprint": "df92c95a7c9b56c2af99b290c39d8471c3e6cbf9dc33dc9bdb4116b98d465cc9",  # pylint: disable=line-too-long
         "invoice": "xxxxxx",
         "licensee": "ReductStore,LLC",
         "plan": "UNLIMITED",

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -15,7 +15,7 @@ from reduct import (
     Permissions,
     FullTokenInfo,
 )
-from .conftest import requires_env
+from .conftest import requires_env, requires_api
 
 
 @pytest_asyncio.fixture(name="with_token")
@@ -76,6 +76,7 @@ async def test__info(client):
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("bucket_1", "bucket_2")
 @requires_env("RS_LICENSE_PATH")
+@requires_api("1.9")
 async def test__info_with_license(client):
     """Should get information about storage with license"""
     info: ServerInfo = await client.info()


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The SDK has the `license` field in `ServerInfo` with the license information:

```python
    info: ServerInfo = await client.info()
    assert info.license.device_number == 1
    assert info.license.device_number == 1
    assert info.license.disk_quota == 0
    assert info.license.expiry_date.isoformat() == "2035-01-01T00:00:00+00:00"
    assert (
        info.license.fingerprint
        == "df92c95a7c9b56c2af99b290c39d8471c3e6cbf9dc33dc9bdb4116b98d465cc9"
    )
    assert info.license.invoice == "xxxxxx"
    assert info.license.licensee == "ReductStore,LLC"
    assert info.license.plan == "UNLIMITED"

```

### Related issues

--

### Does this PR introduce a breaking change?

No

### Other information:
