### PR TITLE
RS-196: accept timestamps in many formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-182: Add flag verify_ssl to Client, [PR-102](https://github.com/reductstore/reduct-py/pull/102)
 - RS-176: Add license field to ServerInfo, [PR-105](https://github.com/reductstore/reduct-py/pull/105)
+- RS-196: accept timestamps in many formats, [PR-196](https://github.com/reductstore/reduct-py/pull/106)
 
 ## [1.8.1] - 2023-01-31
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install reduct-py
 Here is an example of how to use this package to create a bucket, write data to it, and read data from it:
 
 ```python
-import time
+from datetime import datetime
 import asyncio
 from reduct import Client, Bucket
 
@@ -41,7 +41,7 @@ async def main():
     bucket: Bucket = await client.create_bucket("my-bucket", exist_ok=True)
 
     # Write data to the bucket
-    ts = time.time_ns() / 1000
+    ts = datetime.now()
     await bucket.write("entry-1", b"Hey!!", ts)
 
     # Read data from the bucket

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -220,7 +220,8 @@ class Bucket:
             entry_name: name of entry in the bucket
             data: bytes to write or async iterator
             timestamp: timestamp of record. int (UNIX timestamp in microseconds),
-                datetime, float (UNIX timestamp in seconds), str (ISO 8601 string). If None: current time
+                datetime, float (UNIX timestamp in seconds), str (ISO 8601 string).
+                If None: current time
             content_length: content size in bytes,
                 needed only when the data is an iterator
         Keyword Args:
@@ -230,7 +231,8 @@ class Bucket:
             ReductError: if there is an HTTP error
 
         Examples:
-            >>> await bucket.write("entry-1", b"some_data", timestamp="2021-09-10T10:30:00")
+            >>> await bucket.write("entry-1", b"some_data",
+            >>>    timestamp="2021-09-10T10:30:00")
             >>>
             >>> # You can write data chunk-wise using an asynchronous iterator and the
             >>> # size of the content:
@@ -311,11 +313,14 @@ class Bucket:
     ) -> AsyncIterator[Record]:
         """
         Query data for a time interval
-        The time interval is defined by the start and stop parameters and can be int (UNIX timestamp in microseconds),
-        datetime, float (UNIX timestamp in seconds) or str (ISO 8601 string).
+        The time interval is defined by the start and stop parameters that can be:
+        int (UNIX timestamp in microseconds), datetime,
+        float (UNIX timestamp in seconds) or str (ISO 8601 string).
+
         Args:
             entry_name: name of entry in the bucket
-            start: the beginning of the time interval. If None, then from the first record
+            start: the beginning of the time interval.
+                If None, then from the first record
             stop: the end of the time interval. If None, then to the latest record
             ttl: Time To Live of the request in seconds
         Keyword Args:
@@ -376,12 +381,14 @@ class Bucket:
     ) -> AsyncIterator[Record]:
         """
         Query records from the start timestamp and wait for new records
-        The time interval is defined by the start and stop parameters and can be int (UNIX timestamp in microseconds),
-        datetime, float (UNIX timestamp in seconds) or str (ISO 8601 string).
+        The time interval is defined by the start and stop parameters
+        that can be: int (UNIX timestamp in microseconds) datetime,
+        float (UNIX timestamp in seconds) or str (ISO 8601 string).
 
         Args:
             entry_name: name of entry in the bucket
-            start: the beginning timestamp to read records. If None, then from the first record.
+            start: the beginning timestamp to read records.
+                If None, then from the first record.
             poll_interval: inteval to ask new records in seconds
         Keyword Args:
             include (dict): query records which have all labels from this dict

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -178,7 +178,7 @@ class Bucket:
     async def read(
         self,
         entry_name: str,
-        timestamp: Optional[int | datetime | float | str] = None,
+        timestamp: Optional[Union[int, datetime, float, str]] = None,
         head: bool = False,
     ) -> Record:
         """
@@ -209,7 +209,7 @@ class Bucket:
         self,
         entry_name: str,
         data: Union[bytes, AsyncIterator[bytes]],
-        timestamp: Optional[int | datetime | float | str] = None,
+        timestamp: Optional[Union[int, datetime, float, str]] = None,
         content_length: Optional[int] = None,
         **kwargs,
     ):
@@ -306,8 +306,8 @@ class Bucket:
     async def query(
         self,
         entry_name: str,
-        start: Optional[int | datetime | float | str] = None,
-        stop: Optional[int | datetime | float | str] = None,
+        start: Optional[Union[int, datetime, float, str]] = None,
+        stop: Optional[Union[int, datetime, float, str]] = None,
         ttl: Optional[int] = None,
         **kwargs,
     ) -> AsyncIterator[Record]:
@@ -375,7 +375,7 @@ class Bucket:
     async def subscribe(
         self,
         entry_name: str,
-        start: Optional[int | datetime | float | str] = None,
+        start: Optional[Union[int, datetime, float, str]] = None,
         poll_interval=1.0,
         **kwargs,
     ) -> AsyncIterator[Record]:

--- a/reduct/record.py
+++ b/reduct/record.py
@@ -4,7 +4,16 @@ import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 from functools import partial
-from typing import Dict, Callable, AsyncIterator, Awaitable, Optional, List, Tuple
+from typing import (
+    Dict,
+    Callable,
+    AsyncIterator,
+    Awaitable,
+    Optional,
+    List,
+    Tuple,
+    Union,
+)
 
 from aiohttp import ClientResponse
 
@@ -47,7 +56,7 @@ class Batch:
 
     def add(
         self,
-        timestamp: int | datetime | float | str,
+        timestamp: Union[int, datetime, float, str],
         data: bytes,
         content_type: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,

--- a/reduct/time.py
+++ b/reduct/time.py
@@ -1,11 +1,12 @@
 """Helper functions for time-related operations."""
 
 from datetime import datetime
+from typing import Union
 
 TIME_PRECISION = 1_000_000
 
 
-def unix_timestamp_from_any(timestamp: int | datetime | float | str) -> int:
+def unix_timestamp_from_any(timestamp: Union[int, datetime, float, str]) -> int:
     """Convert timestamp to UNIX timestamp in microseconds
     Args:
         timestamp (int | datetime | float | str): int (UNIX timestamp in microseconds),

--- a/reduct/time.py
+++ b/reduct/time.py
@@ -1,4 +1,5 @@
 """Helper functions for time-related operations."""
+
 from datetime import datetime
 
 TIME_PRECISION = 1_000_000

--- a/reduct/time.py
+++ b/reduct/time.py
@@ -1,0 +1,54 @@
+"""Helper functions for time-related operations."""
+from datetime import datetime
+
+TIME_PRECISION = 1_000_000
+
+
+def unix_timestamp_from_any(timestamp: int | datetime | float | str) -> int:
+    """Convert timestamp to UNIX timestamp in microseconds
+    Args:
+        timestamp (int | datetime | float | str): int (UNIX timestamp in microseconds),
+            datetime, float (UNIX timestamp in seconds), str (ISO 8601 string)
+    Returns:
+        int: UNIX timestamp in microseconds
+    """
+    if isinstance(timestamp, datetime):
+        return int(timestamp.timestamp() * TIME_PRECISION)
+    if isinstance(timestamp, str):
+        return int(
+            datetime.fromisoformat(timestamp.replace("Z", "+00:00")).timestamp()
+            * TIME_PRECISION
+        )
+    if isinstance(timestamp, float):
+        return int(timestamp * TIME_PRECISION)
+    return int(timestamp)
+
+
+def unix_timestamp_to_datetime(timestamp: int) -> datetime:
+    """Convert UNIX timestamp to datetime
+    Args:
+        timestamp (int): UNIX timestamp in microseconds
+    Returns:
+        datetime: timestamp as datetime
+    """
+    return datetime.fromtimestamp(timestamp / TIME_PRECISION)
+
+
+def unix_timestamp_to_iso(timestamp: int) -> str:
+    """Convert UNIX timestamp to ISO 8601 string
+    Args:
+        timestamp (int): UNIX timestamp in microseconds
+    Returns:
+        str: timestamp as ISO 8601 string
+    """
+    return unix_timestamp_to_datetime(timestamp).isoformat()
+
+
+def unix_timestamp_to_py_timestamp(timestamp: int) -> float:
+    """Convert UNIX timestamp to Python timestamp
+    Args:
+        timestamp (int): UNIX timestamp in microseconds
+    Returns:
+        float: timestamp as Python timestamp
+    """
+    return timestamp / TIME_PRECISION


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The SDK received only UNIX time in microseconds for timestamps that was a source of many confusions. Now a user can use the `datetime` type, a UNIX timestamp in seconds as float or an ISO string.

### Related issues

---

### Does this PR introduce a breaking change?

No

### Other information:
