### PR TITLE
Fix timestamps in batch writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## Fixed:
+
+- Timestamps in batch writing, [PR-109](https://github.com/reductstore/reduct-py/pull/109)
+
 ## [1.9.0] - 2023-03-08
 
 ### Added:

--- a/reduct/record.py
+++ b/reduct/record.py
@@ -90,7 +90,7 @@ class Batch:
             last=False,
         )
 
-        self._records[timestamp] = record
+        self._records[record.timestamp] = record
 
     def items(self) -> List[Tuple[int, Record]]:
         """Get records as dict items"""

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -424,10 +424,11 @@ async def test_read_batched_records_in_random_order_chunks(bucket_1, size):
 async def test_batched_write(bucket_1):
     """Should write batched records"""
     batch = Batch()
+    # use different timestamp formats
     batch.add(1000, b"Hey,", "plain/text", {"label1": "value1"})
-    batch.add(2000, b"how", "plain/text", {"label2": "value2"})
+    batch.add(datetime.fromtimestamp(0.002), b"how", "plain/text", {"label2": "value2"})
     batch.add(
-        3000,
+        datetime.fromtimestamp(0.003).isoformat(),
         b"are",
         "plain/text",
     )


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

When a user uses strings or `datetime `for timestamps and tries to write a batch, they have an error:

```
reduct.error.ReductError: Status 422: Invalid header'x-reduct-time-xxx': must be an unix timestamp in microseconds
```

I've fixed the translation between different types of timestamps.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
