### PR TITLE
RS-31: Add Bucket.update and Bucket.update_batch method for changing labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- RS-31: `Bucket.update` and `Bucket.update_batch` method for changing labels, [PR-113](https://github.com/reductstore/reduct-py/pull/113)
+
 ## [1.10.0] - 2024-06-11
 
 ### Added:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package provides an asynchronous HTTP client for interacting with  [ReductS
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.10](https://www.reduct.store/docs/http-api)
+* Supports the [ReductStore HTTP API v1.11](https://www.reduct.store/docs/http-api)
 * Bucket management
 * API Token management
 * Write, read and query data

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -305,7 +305,8 @@ class Bucket:
             ReductError: if there is an HTTP error
 
         Examples:
-            >>> await bucket.update("entry-1", "2022-01-01T01:00:00", {"label1": "value1", "label2": ""})
+            >>> await bucket.update("entry-1", "2022-01-01T01:00:00",
+                    {"label1": "value1", "label2": ""})
 
         """
         timestamp = unix_timestamp_from_any(timestamp)

--- a/reduct/record.py
+++ b/reduct/record.py
@@ -57,7 +57,7 @@ class Batch:
     def add(
         self,
         timestamp: Union[int, datetime, float, str],
-        data: bytes,
+        data: bytes = b"",
         content_type: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,
     ):
@@ -70,7 +70,8 @@ class Batch:
             labels: labels of record (default: {})
         """
         if content_type is None:
-            content_type = "application/octet-stream"
+            content_type = ""
+
         if labels is None:
             labels = {}
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Two new methods for changing labels:

```python
    await bucket_1.update(
        "entry-2", 3000000, {"label1": "new-value", "label2": "", "label3": "value3"}
    )
```

and 

```python
    batch = Batch()
    batch.add(3000000, labels={"label1": "new-value", "label2": "", "label3": "value3"})
    batch.add(4000000, labels={"label1": "new-value", "label2": "", "label4": "value4"})

    errors = await bucket_1.update_batch("entry-2", batch)
```

### Related issues

reductstore/reductstore#517

### Does this PR introduce a breaking change?

No

### Other information:
