### PR TITLE
RS-318: Add Bucket.rename_entry method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-418: `Bucket.remove_record`, `Bucket.remove_batch` and `Bucket.remove_query` to remove records, [PR-114](https://github.com/reductstore/reduct-py/pull/114)
 - RS-389: QuotaType.HARD, [PR-115](https://github.com/reductstore/reduct-py/pulls/115)
+- RS-318: Add `Bucket.rename_entry` method, [PR-117](https://github.com/reductstore/reduct-py/pull/117)
 
 ## [1.11.0] - 2024-08-19
 

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -247,6 +247,19 @@ class Bucket:
 
         return json.loads(resp)["removed_records"]
 
+    async def rename_entry(self, old_name: str, new_name: str):
+        """
+        Rename entry
+        Args:
+            old_name: old name of entry
+            new_name: new name of entry
+        Raises:
+            ReductError: if there is an HTTP error
+        """
+        await self._http.request_all(
+            "PUT", f"/b/{self.name}/{old_name}/rename", json={"new_name": new_name}
+        )
+
     @asynccontextmanager
     async def read(
         self,

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -584,3 +584,12 @@ async def test_remove_query(bucket_1):
     records = [record async for record in bucket_1.query("entry-2")]
     assert len(records) == 1
     assert records[0].timestamp == 5000000
+
+
+@pytest.mark.asyncio
+@requires_api("1.12")
+async def test_rename_entry(bucket_1):
+    """Should rename an entry"""
+    await bucket_1.rename_entry("entry-2", "new-entry")
+    entries = await bucket_1.get_entry_list()
+    assert entries[1].name == "new-entry"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The `Bucket.rename_entry` method was added.


### Related issues

https://github.com/reductstore/reductstore/pull/596

### Does this PR introduce a breaking change?

No

### Other information:
