### PR TITLE
RS-419: Add Bucket.rename method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-418: `Bucket.remove_record`, `Bucket.remove_batch` and `Bucket.remove_query` to remove records, [PR-114](https://github.com/reductstore/reduct-py/pull/114)
 - RS-389: QuotaType.HARD, [PR-115](https://github.com/reductstore/reduct-py/pulls/115)
 - RS-318: Add `Bucket.rename_entry` method, [PR-117](https://github.com/reductstore/reduct-py/pull/117)
+- RS-419: Add `Bucket.rename` method, [PR-118](https://github.com/reductstore/reduct-py/pull/118)
 
 ## [1.11.0] - 2024-08-19
 

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -260,6 +260,19 @@ class Bucket:
             "PUT", f"/b/{self.name}/{old_name}/rename", json={"new_name": new_name}
         )
 
+    async def rename(self, new_name: str):
+        """
+        Rename bucket
+        Args:
+            new_name: new name of bucket
+        Raises:
+            ReductError: if there is an HTTP error
+        """
+        await self._http.request_all(
+            "PUT", f"/b/{self.name}/rename", json={"new_name": new_name}
+        )
+        self.name = new_name
+
     @asynccontextmanager
     async def read(
         self,

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -593,3 +593,11 @@ async def test_rename_entry(bucket_1):
     await bucket_1.rename_entry("entry-2", "new-entry")
     entries = await bucket_1.get_entry_list()
     assert entries[1].name == "new-entry"
+
+
+@pytest.mark.asyncio
+@requires_api("1.12")
+async def test_rename_bucket(bucket_1):
+    """Should rename a bucket"""
+    await bucket_1.rename("new-bucket")
+    assert bucket_1.name == "new-bucket"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The `Bucket.rename` method was added.

### Related issues

https://github.com/reductstore/reductstore/pull/597

### Does this PR introduce a breaking change?

No

### Other information:
