### PR TITLE
Fix time converting in Bucket.remove_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-466: Reorganize API messages for better documentation, [PR-120](https://github.com/reductstore/reduct-py/pull/120)
 
+## Fixed
+
+- Time converting in `Bucket.remove_query`, [PR-122](https://github.com/reductstore/reduct-py/pull/122)
+
 ## [1.12.0] - 2024-10-04
 
 ### Added:

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -175,6 +175,9 @@ class Bucket:
             and self._http.api_version[0] == 1
             and self._http.api_version[1] >= 13
         ):
+            start = unix_timestamp_from_any(start) if start else None
+            stop = unix_timestamp_from_any(stop) if stop else None
+
             query_message = QueryEntry(
                 query_type=QueryType.REMOVE, start=start, stop=stop, when=when, **kwargs
             )

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -610,6 +610,16 @@ async def test_remove_query_when(bucket_1):
 
 
 @pytest.mark.asyncio
+@requires_api("1.13")
+async def test_remove_query_when_float_time(bucket_1):
+    """Should remove records by condition"""
+    removed = await bucket_1.remove_query(
+        "entry-2", start=0.0, when={"&number": {"$eq": 2}}
+    )
+    assert removed == 1
+
+
+@pytest.mark.asyncio
 @requires_api("1.12")
 async def test_rename_entry(bucket_1):
     """Should rename an entry"""


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

This PR fixes a time bug in Bucket.remove_query when the timestamp is float or string.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
