### PR TITLE
RS-628:  Support `ext` parameter in query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           --env RS_API_TOKEN=${{matrix.token}}
           --env RS_LOG_LEVEL=DEBUG
           --env RS_LICENSE_PATH=${{matrix.license}}
-          --env RS_EXT_PATH=/tmp  # activate extension feature
+          --env RS_EXT_PATH=/tmp
           -d reduct/store:${{matrix.reductstore_version}}
 
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
           --env RS_API_TOKEN=${{matrix.token}}
           --env RS_LOG_LEVEL=DEBUG
           --env RS_LICENSE_PATH=${{matrix.license}}
+          --env RS_EXT_PATH=/tmp  # activate extension feature
           -d reduct/store:${{matrix.reductstore_version}}
 
       - name: Run Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- RS-550: Add when condition to replication settings, [PR-123](https://github.com/reductstore/reduct-py/pull/123)
+- RS-550: Add `when` condition to replication settings, [PR-123](https://github.com/reductstore/reduct-py/pull/123)
 
 ## [1.13.0] - 2024-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- RS-628: Support `ext` parameter in `Bucket.query`, [PR-125](https://github.com/reductstore/reduct-py/pull/125)
+
 ## [1.14.0] - 2025-02-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package provides an asynchronous HTTP client for interacting with  [ReductS
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.14](https://www.reduct.store/docs/http-api)
+* Supports the [ReductStore HTTP API v1.15](https://www.reduct.store/docs/http-api)
 * Bucket management
 * API Token management
 * Write, read and query data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ Blog = "https://www.reduct.store/blog"
 
 
 [tool.pytest.ini_options]
-asyncio_mode = "strict"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope="function"
 
 [tool.pylint]
 max-line-length = 88

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -167,6 +167,7 @@ class Bucket:
             each_s(Union[int, float]): remove a record for each S seconds
             each_n(int): remove each N-th record
             strict(bool): if True: strict query
+            ext (dict): extended query parameters
         Returns:
             number of removed records
         """
@@ -570,7 +571,13 @@ class Bucket:
         start = unix_timestamp_from_any(start) if start else None
         stop = unix_timestamp_from_any(stop) if stop else None
         query_message = QueryEntry(
-            query_type=query_type, start=start, stop=stop, when=when, ttl=ttl, **kwargs
+            query_type=query_type,
+            start=start,
+            stop=stop,
+            when=when,
+            ttl=ttl,
+            only_meatadata=kwargs.get("head", False),
+            **kwargs,
         )
         data = query_message.model_dump_json()
         url = f"/b/{self.name}/{entry_name}/q"

--- a/reduct/bucket.py
+++ b/reduct/bucket.py
@@ -60,7 +60,9 @@ class Bucket:
         Raises:
             ReductError: if there is an HTTP error
         """
-        await self._http.request_all("PUT", f"/b/{self.name}", data=settings.json())
+        await self._http.request_all(
+            "PUT", f"/b/{self.name}", data=settings.model_dump_json()
+        )
 
     async def info(self) -> BucketInfo:
         """

--- a/reduct/msg/bucket.py
+++ b/reduct/msg/bucket.py
@@ -138,3 +138,6 @@ class QueryEntry(BaseModel):
 
     strict: Optional[bool] = None
     """strict mode for when clause"""
+
+    ext: Optional[Dict[str, Dict]] = None
+    """extended query options"""

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -634,3 +634,12 @@ async def test_rename_bucket(bucket_1):
     """Should rename a bucket"""
     await bucket_1.rename("new-bucket")
     assert bucket_1.name == "new-bucket"
+
+
+@pytest.mark.asyncio
+@requires_api("1.15")
+async def test_query_extension(bucket_1):
+    """Should query with additional parameters for extensions"""
+    with pytest.raises(ReductError, match="Unknown extension"):
+        async for _record in bucket_1.query("entry-2", ext={"test": {}}):
+            pass

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -108,7 +108,7 @@ async def test__list(client, bucket_1, bucket_2):
 async def test__create_bucket_default_settings(client, bucket_1):
     """Should create a bucket with default settings"""
     settings = await bucket_1.get_settings()
-    assert settings.model_dump() == (await client.info()).defaults.bucket.dict()
+    assert settings.model_dump() == (await client.info()).defaults.bucket.model_dump()
 
 
 @pytest.mark.asyncio
@@ -125,7 +125,7 @@ async def test__create_bucket_custom_settings(client):
         "bucket", BucketSettings(max_block_records=10000)
     )
     settings = await bucket.get_settings()
-    assert settings.dict() == {
+    assert settings.model_dump() == {
         "max_block_size": 64000000,
         "max_block_records": 10000,
         "quota_size": 0,
@@ -140,7 +140,7 @@ async def test__create_bucket_quota(client, quota_type):
     """Should create a bucket with custom settings"""
     bucket = await client.create_bucket("bucket", BucketSettings(quota_type=quota_type))
     settings = await bucket.get_settings()
-    assert settings.dict()["quota_type"] == quota_type
+    assert settings.model_dump()["quota_type"] == quota_type
 
 
 @pytest.mark.asyncio
@@ -206,7 +206,7 @@ async def test__get_token(client, with_token):
     token = await client.get_token(with_token)
     assert token.name == with_token
     assert not token.is_provisioned
-    assert token.permissions.dict() == {
+    assert token.permissions.model_dump() == {
         "full_access": True,
         "read": ["bucket-1"],
         "write": ["bucket-2"],

--- a/tests/replication_test.py
+++ b/tests/replication_test.py
@@ -96,4 +96,4 @@ async def test__replication_with_when(client):
     await client.create_replication(replication_name, settings)
     replication = await client.get_replication_detail(replication_name)
 
-    assert replication.settings.when == {"&number": {"$gt": 1}}
+    assert replication.Th.when == {"&number": {"$gt": 1}}

--- a/tests/replication_test.py
+++ b/tests/replication_test.py
@@ -96,4 +96,4 @@ async def test__replication_with_when(client):
     await client.create_replication(replication_name, settings)
     replication = await client.get_replication_detail(replication_name)
 
-    assert replication.Th.when == {"&number": {"$gt": 1}}
+    assert replication.settings.when == {"&number": {"$gt": 1}}


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR adds the `ext` parameter to the Bucket.query method to process data with extensions:

```python
async for _record in bucket_1.query("entry-2", ext={"ext-name": {"param": 10}}):
      pass
```

### Related issues

https://github.com/reductstore/reductstore/pull/762

### Does this PR introduce a breaking change?

No

### Other information:
