### PR TITLE
RS-670:  Drop Python 3.8 and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python: ["3.8"]
+        python: ["3.9"]
         reductstore_version: ["latest", "main"]
         token: ["", "ACCESS_TOKEN"]
         license: ["", "/workdir/lic.key"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 
-dependencies = ["aiohttp~=3.8", "pydantic~=2.4", "deprecation~=2.1"]
+dependencies = ["aiohttp >=3.8,<4", "pydantic >=2.4,<3", "deprecation >=2.1,<3"]
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 name = "reduct-py"
 version = "1.15.0"
 description = "ReductStore Client SDK for Python"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["sdk", "reductstore", "api client", "database", "time series database"]


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Internal

### What was changed?

Python 3.8 is legacy. The PR bumps the minimum Python version  up to 3.8 and makes the dependency versioning loose in scope of the major versions. 

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
