### PR TITLE
Remove deprecated exclude\include parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Check server API version and warn if it's too old, [PR-129](https://github.com/reductstore/reduct-py/pull/129)
 
+### Removed
+
+- Deprecated `include` abd `exclude` parameters in `Bucket.query` and `ReplicationSettings`, [PR-132](https://github.com/reductstore/reduct-py/pull/132)
+
 ## [1.15.0] - 2025-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Deprecated `include` abd `exclude` parameters in `Bucket.query` and `ReplicationSettings`, [PR-132](https://github.com/reductstore/reduct-py/pull/132)
+- Deprecated `include` and `exclude` parameters in `Bucket.query` and `ReplicationSettings`, [PR-132](https://github.com/reductstore/reduct-py/pull/132)
 
 ## [1.15.0] - 2025-05-05
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package provides an asynchronous HTTP client for interacting with  [ReductS
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.15](https://www.reduct.store/docs/http-api)
+* Supports the [ReductStore HTTP API v1.16](https://www.reduct.store/docs/http-api)
 * Bucket management
 * API Token management
 * Write, read and query data
@@ -78,9 +78,9 @@ The library is backward compatible with the previous versions. However, some met
 removed in the future releases. Please refer to **CHANGELOG.md** for more details.
 The SDK supports the following ReductStore API versions:
 
+* v1.16
 * v1.15
 * v1.14
-* v1.13
 
 It can work with newer and older versions, but it is not guaranteed that all features will work as expected because
 the API may change and some features may be deprecated or the SDK may not support them yet.

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -37,18 +37,6 @@ from reduct.time import unix_timestamp_from_any
 
 
 def _check_deprecated_params(kwargs):
-    if "include" in kwargs:
-        warnings.warn(
-            "The 'include' argument is deprecated and will be removed in v1.16.0,"
-            " use 'when' instead.",
-            DeprecationWarning,
-        )
-    if "exclude" in kwargs:
-        warnings.warn(
-            "The 'exclude' argument is deprecated and will be removed in v1.16.0,"
-            " use 'when' instead.",
-            DeprecationWarning,
-        )
     if "each_s" in kwargs:
         warnings.warn(
             "The 'each_s' argument is deprecated and will be removed in v1.18.0,"
@@ -196,10 +184,6 @@ class Bucket:
             stop: the end of the time interval. If None, then to the latest record
             when: condtion to filter
         Keyword Args:
-            include (dict): remove records which have all labels
-                from this dict (DEPRECATED use when)
-            exclude (dict): remove records which doesn't have all labels
-                from this (DEPRECATED use when)
             each_s(Union[int, float]): remove a record for each S seconds
                 (DEPRECATED use $each_t in when)
             each_n(int): remove each N-th record
@@ -449,10 +433,6 @@ class Bucket:
             ttl: Time To Live of the request in seconds
             when: condtion to filter records
         Keyword Args:
-            include (dict): query records which have all labels
-                from this dict (DEPRECATED use when)
-            exclude (dict): query records which doesn't have all labels
-                from this (DEPRECATED use when)
             head (bool): if True: get only the header of a recod with metadata
             each_s(Union[int, float]): return a record for each S seconds
                 (DEPRECATED use $each_t in when)

--- a/pkg/reduct/msg/bucket.py
+++ b/pkg/reduct/msg/bucket.py
@@ -109,12 +109,6 @@ class QueryEntry(BaseModel):
     stop: Optional[int] = None
     """end time in microseconds"""
 
-    include: Dict[str, str] = Field({}, deprecated="Use when instead")
-    """include labels. Added for backward compatibility"""
-
-    exclude: Dict[str, str] = Field({}, deprecated="Use when instead")
-    """exclude labels. Added for backward compatibility"""
-
     each_s: Optional[float] = None
     """return a record every S seconds"""
 

--- a/pkg/reduct/msg/bucket.py
+++ b/pkg/reduct/msg/bucket.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import Optional, List, Dict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class QuotaType(Enum):

--- a/pkg/reduct/msg/replication.py
+++ b/pkg/reduct/msg/replication.py
@@ -67,22 +67,7 @@ class ReplicationSettings(BaseModel):
     entries: List[str] = Field([])
     """list of entries to replicate. If empty, all entries are replicated.
     Wildcards are supported"""
-    include: Dict[str, str] = Field(
-        {},
-        deprecated=deprecated(
-            "Use the `when` method to set the labels to exclude from the query. "
-            "It will be remove in v1.16.0."
-        ),
-    )
-    """replicate only records with these labels"""
-    exclude: Dict[str, str] = Field(
-        {},
-        deprecated=deprecated(
-            "Use the `when` method to set the labels to exclude from the query. "
-            "It will be remove in v1.16.0."
-        ),
-    )
-    """exclude records with these labels"""
+
     each_s: Optional[float] = Field(
         None,
         deprecated=deprecated(

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -314,7 +314,7 @@ async def test_no_content_query(bucket_1):
     """Should return empty list if no content"""
     records = [
         record
-        async for record in bucket_1.query("entry-2", include={"label1": "value1"})
+        async for record in bucket_1.query("entry-2", when={"&number": {"$eq": 0}})
     ]
     assert len(records) == 0
 


### PR DESCRIPTION
Closes #132

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Removal

### What was changed?

- **Removed deprecated `exclude` and `include` parameters:**  
  All usage of the deprecated `exclude` and `include` parameters has been removed from the codebase. These parameters are no longer supported and their presence has been fully eliminated from public APIs and internal logic.
- **Code and documentation cleanup:**  
  Any references, documentation comments, or code paths that mentioned or handled `exclude`/`include` have been updated or deleted to reflect their removal.

### Related issues

#132 , https://github.com/reductstore/reductstore/issues/873

### Does this PR introduce a breaking change?

Yes

### Other information:
