### PR TITLE
Fix head flag in Bucket.query method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecated `include` and `exclude` parameters in `Bucket.query` and `ReplicationSettings`, [PR-132](https://github.com/reductstore/reduct-py/pull/132)
 
+
+### Fixed
+
+- `head` flag in `Bucket.query` method, [PR-133](https://github.com/reductstore/reduct-py/pull/133)
+
 ## [1.15.0] - 2025-05-05
 
 ### Added

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -201,12 +201,11 @@ class Bucket:
         query_message = QueryEntry(
             query_type=QueryType.REMOVE, start=start, stop=stop, when=when, **kwargs
         )
-        data = query_message.model_dump_json()
         url = f"/b/{self.name}/{entry_name}/q"
         resp, _ = await self._http.request_all(
             "POST",
             url,
-            data=data,
+            json=query_message.model_dump(),
         )
 
         return json.loads(resp)["removed_records"]

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -205,7 +205,8 @@ class Bucket:
         resp, _ = await self._http.request_all(
             "POST",
             url,
-            json=query_message.model_dump(),
+            data=query_message.model_dump_json(),
+            content_type="application/json",
         )
 
         return json.loads(resp)["removed_records"]
@@ -549,15 +550,15 @@ class Bucket:
             stop=stop,
             when=when,
             ttl=ttl,
-            only_meatadata=kwargs.get("head", False),
+            only_metadata=kwargs.get("head", False),
             **kwargs,
         )
-        data = query_message.model_dump_json()
         url = f"/b/{self.name}/{entry_name}/q"
         data, _ = await self._http.request_all(
             "POST",
             url,
-            data=data,
+            data=query_message.model_dump_json(),
+            content_type="application/json",
         )
         query_id = json.loads(data)["id"]
         return query_id

--- a/pkg/reduct/msg/bucket.py
+++ b/pkg/reduct/msg/bucket.py
@@ -121,7 +121,7 @@ class QueryEntry(BaseModel):
     ttl: Optional[int] = None
     """time to live of the query in seconds"""
 
-    only_meatadata: Optional[bool] = None
+    only_metadata: Optional[bool] = None
     """return only metadata"""
 
     continuous: Optional[bool] = None


### PR DESCRIPTION
Hotfix

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The `QueryEntry` message had a typo and the flag `head` didn't work properly. The PR fixes the flag and MIME type of the request.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
