### PR TITLE
Add filename parameter to Bucket.create_query_link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implement Bucket.create_query_link method, [PR-134](https://github.com/reductstore/reduct-py/pull/134)
+- Add filename parameter to Bucket.create_query_link, [PR-135](https://github.com/reductstore/reduct-py/pull/135)
 
 ## [1.16.0] - 2025-08-29
 

--- a/pkg/reduct/bucket.py
+++ b/pkg/reduct/bucket.py
@@ -565,12 +565,13 @@ class Bucket:
         Keyword Args:
             record_index: if not None, the link will point to a specific record
             expire_at: if None, the link will expire in 24 hours
+            file_name: file name for download, if None: entry_name_index.bin
 
         """
         start = unix_timestamp_from_any(start) if start else None
         stop = unix_timestamp_from_any(stop) if stop else None
 
-        record_index: Optional[int] = kwargs.get("record_index", None)
+        record_index = kwargs.get("record_index", 0)
         expire_at: Optional[datetime] = kwargs.get("expire_at", None)
 
         if expire_at is None:
@@ -592,10 +593,18 @@ class Bucket:
             expire_at=int(expire_at.timestamp()),
         )
 
-        print(query_link_params.model_dump_json())
+        file_name = kwargs.get(
+            "file_name",
+            (
+                f"{entry}_{record_index}.bin"
+                if record_index is not None
+                else f"{entry}.bin"
+            ),
+        )
+
         body, _ = await self._http.request_all(
             "POST",
-            "/links",
+            f"/links/{file_name}",
             data=query_link_params.model_dump_json(),
             content_type="application/json",
         )

--- a/tests/bucket_test.py
+++ b/tests/bucket_test.py
@@ -687,3 +687,11 @@ async def test_create_query_link_record_index(bucket_1):
     assert resp.headers["content-type"] == "application/octet-stream"
     assert resp.headers["x-reduct-time"] == "4000000"
     assert resp.headers["x-reduct-label-number"] == "2"
+
+
+@pytest.mark.asyncio
+@requires_api("1.17")
+async def test_create_query_link_filename(bucket_1):
+    """Should create a query link with record index"""
+    link = await bucket_1.create_query_link("entry-2", file_name="data.txt")
+    assert "links/data.txt?" in link


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Update

### What was changed?

The API was changed and filename is necessary.

### Related issues

#134 

### Does this PR introduce a breaking change?

No

### Other information:
